### PR TITLE
Require the same version of json in both rpm and gem spec

### DIFF
--- a/rubygem-runcible.spec
+++ b/rubygem-runcible.spec
@@ -54,7 +54,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{gem_name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       ruby(abi) = %{rubyabi}
 Requires:       ruby(rubygems) 
-Requires:       rubygem(json) 
+Requires:       rubygem(json) = 1.7.5
 Requires:       rubygem(rest-client) >= 1.6.1
 Requires:       rubygem(oauth) 
 Requires:       rubygem(activesupport) >= 3.0.10


### PR DESCRIPTION
We had no version requirement in rpm spec. This could result in different version of rubygem json installed.

Eg. when used in Katello:
Gem loading error: Unable to activate runcible-0.3.2, because json-1.4.6 conflicts with json (= 1.7.5)
