### PR TITLE
consumer - specify different unit key based on content type

### DIFF
--- a/lib/runcible/extensions/consumer.rb
+++ b/lib/runcible/extensions/consumer.rb
@@ -85,10 +85,20 @@ module Runcible
       # @return [Array]           array of formatted content units
       def self.generate_content(type_id, units)
         content = []
+
+        case type_id
+          when 'rpm', 'package_group'
+            unit_key = :name
+          when 'erratum'
+            unit_key = :id
+          else
+            unit_key = :id
+        end
+
         units.each do |unit|
           content_unit = {}
           content_unit[:type_id] = type_id
-          content_unit[:unit_key] = { :name => unit }
+          content_unit[:unit_key] = { unit_key => unit }
           content.push(content_unit)
         end
         content


### PR DESCRIPTION
When installing content (e.g. rpm, package_group, erratum)
using pulp, the 'unit key' used may be different based on
the content type.  This small commit addresses the changes
needed for the supported types.

e.g. rpm and package_group use a unit key of 'name',
     erratum uses a unit key of 'id'
