### PR TITLE
consumer/group - update to allow for update all

### DIFF
--- a/lib/runcible/extensions/consumer.rb
+++ b/lib/runcible/extensions/consumer.rb
@@ -68,7 +68,7 @@ module Runcible
       # @param  [Hash]                 options to pass to content update
       # @return [RestClient::Response]          task representing the update operation
       def self.update_content(id, type_id, units, options={})
-        self.update_units(id, generate_content(type_id, units), options)
+        self.update_units(id, generate_content(type_id, units, options), options)
       end
 
       # Uninstall content from a consumer
@@ -85,8 +85,9 @@ module Runcible
       #
       # @param  [String]  type_id the type of content (e.g. rpm, errata)
       # @param  [Array]   units   array of units
+      # @param  [Hash]    options contains options which may impact the format of the content (e.g :all => true)
       # @return [Array]           array of formatted content units
-      def self.generate_content(type_id, units)
+      def self.generate_content(type_id, units, options={})
         content = []
 
         case type_id
@@ -98,11 +99,18 @@ module Runcible
             unit_key = :id
         end
 
-        units.each do |unit|
+        if options[:all]
           content_unit = {}
           content_unit[:type_id] = type_id
-          content_unit[:unit_key] = { unit_key => unit }
+          content_unit[:unit_key] = {}
           content.push(content_unit)
+        else
+          units.each do |unit|
+            content_unit = {}
+            content_unit[:type_id] = type_id
+            content_unit[:unit_key] = { unit_key => unit }
+            content.push(content_unit)
+          end
         end
         content
       end

--- a/lib/runcible/extensions/consumer_group.rb
+++ b/lib/runcible/extensions/consumer_group.rb
@@ -75,7 +75,7 @@ module Runcible
       # @param  [Hash]                 options  to pass to content update
       # @return [RestClient::Response]          task representing the update operation
       def self.update_content(id, type_id, units, options={})
-        self.update_units(id, generate_content(type_id, units), options)
+        self.update_units(id, generate_content(type_id, units, options), options)
       end
 
       # Uninstall content from a consumer group
@@ -92,8 +92,9 @@ module Runcible
       #
       # @param  [String]  type_id the type of content (e.g. rpm, errata)
       # @param  [Array]   units   array of units
+      # @param  [Hash]    options contains options which may impact the format of the content (e.g :all => true)
       # @return [Array]           array of formatted content units
-      def self.generate_content(type_id, units)
+      def self.generate_content(type_id, units, options={})
         content = []
 
         case type_id
@@ -105,11 +106,18 @@ module Runcible
             unit_key = :id
         end
 
-        units.each do |unit|
+        if options[:all]
           content_unit = {}
           content_unit[:type_id] = type_id
-          content_unit[:unit_key] = { unit_key => unit }
+          content_unit[:unit_key] = {}
           content.push(content_unit)
+        else
+          units.each do |unit|
+            content_unit = {}
+            content_unit[:type_id] = type_id
+            content_unit[:unit_key] = { unit_key => unit }
+            content.push(content_unit)
+          end
         end
         content
       end

--- a/test/extensions/consumer_group_test.rb
+++ b/test/extensions/consumer_group_test.rb
@@ -123,4 +123,12 @@ class TestConsumerGroupExtension < MiniTest::Unit::TestCase
     refute_empty content.select{ |unit| unit[:type_id] == "rpm" }
   end
 
+  def test_generate_content_all
+    content = @extension.generate_content("rpm", ["unit_1"], {:all => true})
+
+    refute_empty content
+    assert_equal "rpm", content.first[:type_id]
+    assert_empty content.first[:unit_key]
+  end
+
 end

--- a/test/extensions/consumer_test.rb
+++ b/test/extensions/consumer_test.rb
@@ -100,11 +100,20 @@ class TestConsumerExtension < MiniTest::Unit::TestCase
     assert_equal 202, response.code
     assert       response["task_id"]
   end
+
   def test_generate_content
     content = @extension.generate_content("rpm", ["unit_1", "unit_2"])
 
     refute_empty content
     refute_empty content.select{ |unit| unit[:type_id] == "rpm" }
+  end
+
+  def test_generate_content_all
+    content = @extension.generate_content("rpm", ["unit_1"], {:all => true})
+
+    refute_empty content
+    assert_equal "rpm", content.first[:type_id]
+    assert_empty content.first[:unit_key]
   end
 
   def test_applicable_errata


### PR DESCRIPTION
This commit contains a small modification to the generate_content
for consumer and consumer group to enable support for users to
request an 'update all' operation on the pulp interface.  The
basic case where this is used is to request 'update all packages
on consumer X'.  (e.g. equivalent to 'yum update' from the consumer).
