### PR TITLE
locking to rest-client less than 1.8

### DIFF
--- a/rubygem-runcible.spec
+++ b/rubygem-runcible.spec
@@ -67,6 +67,7 @@ Requires:       %{?scl_prefix}ruby(abi) = %{rubyabi}
 Requires:       %{?scl_prefix}ruby(rubygems) 
 Requires:       %{?scl_prefix}rubygem(json) 
 Requires:       %{?scl_prefix}rubygem(rest-client) >= 1.6.1
+Requires:       %{?scl_prefix}rubygem(rest-client) < 1.8.0
 Requires:       %{?scl_prefix}rubygem(oauth) 
 Requires:       %{?scl_prefix}rubygem(activesupport) >= 3.0.10
 Requires:       %{?scl_prefix}rubygem(i18n) >= 0.5.0

--- a/runcible.gemspec
+++ b/runcible.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Runcible::VERSION
 
   gem.add_dependency('json')
-  gem.add_dependency('rest-client', '>= 1.6.1')
+  gem.add_dependency('rest-client', ['>= 1.6.1', '< 1.8.0'])
   gem.add_dependency('oauth')
   gem.add_dependency('activesupport', '>= 3.0.10')
   gem.add_dependency('i18n', '>= 0.5.0')


### PR DESCRIPTION
this commit:

https://github.com/rest-client/rest-client/commit/c215b22bdbcb988dcc40117ff45432b0db25175b

broke compatability with rest-client by changing the number of argumets to Response.create().
Since this was a method signature change its somewhat hacky to support both versions.