### PR TITLE
[do not merge] Add 'relative_url' as an optional parameter to the export distributor

### DIFF
--- a/lib/runcible/models/export_distributor.rb
+++ b/lib/runcible/models/export_distributor.rb
@@ -5,16 +5,18 @@ module Runcible
   module Models
     class ExportDistributor < Distributor
       #required attributes
-      attr_accessor 'http', 'https'
+      attr_accessor 'http', 'https', 'relative_url'
 
       # Instantiates a export distributor
       #
       # @param  [boolean]         http  serve the contents over http
       # @param  [boolean]         https serve the contents over https
+      # @param  [string]          relative url
       # @return [Runcible::Extensions::ExportDistributor]
-      def initialize(http, https)
+      def initialize(http, https, relative_url = nil)
         @http = http
         @https = https
+        @relative_url = relative_url
         # Pulp seems to expect the ID to be export_distributor, not a random
         super({:id => type_id})
       end


### PR DESCRIPTION
This change is needed to support https://pulp.plan.io/issues/1394, which allows
for a new config keyword.