### PR TITLE
fixes #13460 - docker v2 - disable v1 support & introduce docker_manifest unit type

### DIFF
--- a/lib/runcible/extensions/docker_manifest.rb
+++ b/lib/runcible/extensions/docker_manifest.rb
@@ -1,0 +1,9 @@
+module Runcible
+  module Extensions
+    class DockerManifest < Runcible::Extensions::Unit
+      def self.content_type
+        'docker_manifest'
+      end
+    end
+  end
+end

--- a/lib/runcible/extensions/repository.rb
+++ b/lib/runcible/extensions/repository.rb
@@ -240,6 +240,26 @@ module Runcible
         unit_search(id, criteria).map { |i| i['metadata'].with_indifferent_access }
       end
 
+      # Retrieves the docker manifest IDs for a single repository
+      #
+      # @param  [String]                id the ID of the repository
+      # @return [RestClient::Response]  the set of repository docker manifest IDs
+      def docker_manifest_ids(id)
+        criteria = {:type_ids => [Runcible::Extensions::DockerManifest.content_type],
+                    :fields => {:unit => [], :association => ['unit_id']}}
+
+        unit_search(id, criteria).map { |i| i['unit_id'] }
+      end
+
+      # Retrieves the docker manifests for a single repository
+      #
+      # @param  [String]                id the ID of the repository
+      # @return [RestClient::Response]  the set of repository docker manifests
+      def docker_manifests(id)
+        criteria = {:type_ids => [Runcible::Extensions::DockerManifest.content_type]}
+        unit_search(id, criteria).map { |i| i['metadata'].with_indifferent_access }
+      end
+
       # Retrieves the docker image IDs for a single repository
       #
       # @param  [String]                id the ID of the repository

--- a/lib/runcible/models/docker_importer.rb
+++ b/lib/runcible/models/docker_importer.rb
@@ -4,7 +4,7 @@ module Runcible
       ID = 'docker_importer'
       REPO_TYPE = 'docker-repo'
 
-      attr_accessor 'upstream_name', 'mask_id'
+      attr_accessor 'upstream_name', 'mask_id', 'enable_v1'
 
       def id
         DockerImporter::ID


### PR DESCRIPTION
NOTE: THIS CHANGE IS BASED ON PULP 2.8

This commit makes 2 changes:
1. update the docker importer to support the 'enable_v1' flag
2. introduce the docker_manifest unit which is being added with
   docker v2