### PR TITLE
Add relative_url to export distributor and allow for publishing group exports

### DIFF
--- a/lib/runcible/models/export_distributor.rb
+++ b/lib/runcible/models/export_distributor.rb
@@ -5,16 +5,18 @@ module Runcible
   module Models
     class ExportDistributor < Distributor
       #required attributes
-      attr_accessor 'http', 'https'
+      attr_accessor 'http', 'https', 'relative_url'
 
       # Instantiates a export distributor
       #
       # @param  [boolean]         http  serve the contents over http
       # @param  [boolean]         https serve the contents over https
+      # @param  [string]          relative url
       # @return [Runcible::Extensions::ExportDistributor]
-      def initialize(http, https)
+      def initialize(http, https, relative_url = nil)
         @http = http
         @https = https
+        @relative_url = relative_url
         # Pulp seems to expect the ID to be export_distributor, not a random
         super({:id => type_id})
       end

--- a/lib/runcible/models/export_distributor.rb
+++ b/lib/runcible/models/export_distributor.rb
@@ -11,7 +11,7 @@ module Runcible
       #
       # @param  [boolean]         http  serve the contents over http
       # @param  [boolean]         https serve the contents over https
-      # @param  [string]          relative url
+      # @param  [string]          relative_url relative url (aka relative path)
       # @return [Runcible::Extensions::ExportDistributor]
       def initialize(http, https, relative_url = nil)
         @http = http

--- a/lib/runcible/models/group_export_distributor.rb
+++ b/lib/runcible/models/group_export_distributor.rb
@@ -1,0 +1,44 @@
+require 'active_support/json'
+require 'securerandom'
+
+module Runcible
+  module Models
+    class GroupExportDistributor < Distributor
+      #required attributes
+      attr_accessor 'http', 'https'
+
+      # Instantiates a group export distributor.
+      #
+      # @param  [boolean]        http  serve the contents over http
+      # @param  [boolean]        https serve the contents over https
+      # @param  [hash]           params additional parameters to send in request
+      # @return [Runcible::Extensions::GroupExportDistributor]
+      def initialize(http = false, https = false, params = {})
+        @http = http
+        @https = https
+        # these two fields are helpful when instantiating a group export
+        # distributor via group creation. It saves a few pulp API calls.
+        @distributor_type_id = type_id
+        @distributor_config = {:http => http, :https => https}
+        super(params)
+      end
+
+      # Distributor Type id
+      #
+      # @return [string]
+      def self.type_id
+        'group_export_distributor'
+      end
+
+      # generate the pulp config for the export distributor
+      #
+      # @return [Hash]
+      def config
+        to_ret = as_json
+        to_ret.delete('auto_publish')
+        to_ret.delete('id')
+        to_ret
+      end
+    end
+  end
+end

--- a/lib/runcible/resources/repository_group.rb
+++ b/lib/runcible/resources/repository_group.rb
@@ -31,6 +31,14 @@ module Runcible
         call(:get, path(id))
       end
 
+      # Retrieves a Repository Group's distributors
+      #
+      # @param  [String]                id  the ID of the Repository group
+      # @return [RestClient::Response]
+      def retrieve_distributors(id)
+        call(:get, path(id) + 'distributors/')
+      end
+
       # Retrieves all Repository Group
       #
       # @return [RestClient::Response]
@@ -62,6 +70,17 @@ module Runcible
       # @return [RestClient::Response]
       def unassociate(id, criteria)
         call(:post, path(id) + 'actions/unassociate/', :payload => {:required => criteria})
+      end
+
+      # Publishes a repository group using the specified distributor
+      #
+      # @param  [String]                id              the id of the repository
+      # @param  [String]                distributor_id  the id of the distributor
+      # @param  [Hash]                  optional  optional params
+      # @return [RestClient::Response]
+      def publish(id, distributor_id, optional = {})
+        call(:post, "#{path(id)}actions/publish/",
+             :payload => {:required => {:id => distributor_id}, :optional => optional})
       end
     end
   end

--- a/test/fixtures/vcr_cassettes/resources/repo_group/retrieve.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group/retrieve.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
     body:
       encoding: US-ASCII
       string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
@@ -24,13 +24,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:28 GMT
+      - Sat, 30 Jan 2016 17:49:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '310'
       Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
       Connection:
       - close
       Content-Type:
@@ -39,13 +39,13 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
         description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
-        [], "_id": {"$oid": "56aba1b4de040332a476fc30"}, "id": "integration_test_repository_group",
+        [], "_id": {"$oid": "56acf7be17f25e2e6f4ffde8"}, "id": "integration_test_repository_group",
         "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:28 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:50 GMT
 - request:
     method: get
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:28 GMT
+      - Sat, 30 Jan 2016 17:49:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -81,15 +81,15 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogbnVsbCwgImRpc3BsYXlfbmFtZSI6ICJmb28iLCAi
         ZGVzY3JpcHRpb24iOiAiVGVzdCBkZXNjcmlwdGlvbi4iLCAiX25zIjogInJl
         cG9fZ3JvdXBzIiwgIm5vdGVzIjoge30sICJyZXBvX2lkcyI6IFtdLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YWJhMWI0ZGUwNDAzMzJhNDc2ZmMzMCJ9LCAiaWQi
+        IjogeyIkb2lkIjogIjU2YWNmN2JlMTdmMjVlMmU2ZjRmZmRlOCJ9LCAiaWQi
         OiAiaW50ZWdyYXRpb25fdGVzdF9yZXBvc2l0b3J5X2dyb3VwIiwgIl9ocmVm
         IjogIi9wdWxwL2FwaS92Mi9yZXBvX2dyb3Vwcy9pbnRlZ3JhdGlvbl90ZXN0
         X3JlcG9zaXRvcnlfZ3JvdXAvIn0=
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:29 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:50 GMT
 - request:
     method: delete
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
     body:
       encoding: US-ASCII
       string: ''
@@ -108,7 +108,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:29 GMT
+      - Sat, 30 Jan 2016 17:49:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -121,5 +121,5 @@ http_interactions:
       encoding: US-ASCII
       string: 'null'
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:29 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:50 GMT
 recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group/retrieve_all.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group/retrieve_all.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
     body:
       encoding: US-ASCII
       string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
@@ -24,13 +24,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:28 GMT
+      - Sat, 30 Jan 2016 17:49:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '310'
       Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
       Connection:
       - close
       Content-Type:
@@ -39,13 +39,13 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
         description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
-        [], "_id": {"$oid": "56aba1b4de040332a476fc2f"}, "id": "integration_test_repository_group",
+        [], "_id": {"$oid": "56acf7be17f25e2e6f4ffde9"}, "id": "integration_test_repository_group",
         "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:28 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:50 GMT
 - request:
     method: get
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:28 GMT
+      - Sat, 30 Jan 2016 17:49:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -81,15 +81,15 @@ http_interactions:
         W3sic2NyYXRjaHBhZCI6IG51bGwsICJkaXNwbGF5X25hbWUiOiAiZm9vIiwg
         ImRlc2NyaXB0aW9uIjogIlRlc3QgZGVzY3JpcHRpb24uIiwgIl9ucyI6ICJy
         ZXBvX2dyb3VwcyIsICJub3RlcyI6IHt9LCAicmVwb19pZHMiOiBbXSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmFiYTFiNGRlMDQwMzMyYTQ3NmZjMmYifSwgImlk
+        ZCI6IHsiJG9pZCI6ICI1NmFjZjdiZTE3ZjI1ZTJlNmY0ZmZkZTkifSwgImlk
         IjogImludGVncmF0aW9uX3Rlc3RfcmVwb3NpdG9yeV9ncm91cCIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb19ncm91cHMvaW50ZWdyYXRpb25fdGVz
         dF9yZXBvc2l0b3J5X2dyb3VwLyJ9XQ==
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:28 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:50 GMT
 - request:
     method: delete
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
     body:
       encoding: US-ASCII
       string: ''
@@ -108,7 +108,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:28 GMT
+      - Sat, 30 Jan 2016 17:49:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -121,5 +121,5 @@ http_interactions:
       encoding: US-ASCII
       string: 'null'
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:28 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:50 GMT
 recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_associate/associate.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_associate/associate.yml
@@ -396,241 +396,6 @@ http_interactions:
     http_version: 
   recorded_at: Fri, 29 Jan 2016 17:07:54 GMT
 - request:
-    method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/
-    body:
-      encoding: US-ASCII
-      string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
-        description."}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '97'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '310'
-      Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
-        description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
-        [], "_id": {"$oid": "56aba1b5de040332a523ca49"}, "id": "integration_test_repository_group",
-        "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:29 GMT
-- request:
-    method: get
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: NOT FOUND
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '452'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
-        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
-        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
-        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
-        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:29 GMT
-- request:
-    method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: US-ASCII
-      string: ! '{"id":"integration_test_id"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '28'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '319'
-      Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repositories/integration_test_id/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
-        {}, "_ns": "repos", "_id": {"$oid": "56aba1b5de040332a523ca4a"}, "id": "integration_test_id",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:29 GMT
-- request:
-    method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/associate/
-    body:
-      encoding: US-ASCII
-      string: ! '{"criteria":{"filters":{"id":{"$in":["integration_test_id"]}}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '63'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '23'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '["integration_test_id"]'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:29 GMT
-- request:
-    method: delete
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '4'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: 'null'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:29 GMT
-- request:
-    method: delete
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/1b83a1d6-1100-425b-8e4b-98fa61b2ba22/",
-        "task_id": "1b83a1d6-1100-425b-8e4b-98fa61b2ba22"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:29 GMT
-- request:
     method: get
     uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/tasks/1b83a1d6-1100-425b-8e4b-98fa61b2ba22/
     body:
@@ -683,4 +448,345 @@ http_interactions:
         ZTA5NzQxZGQ2NDBkNjA3In0=
     http_version: 
   recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/f63faa3c-3d1d-4130-a1d6-463a8e928797/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mNjNmYWEzYy0zZDFkLTQxMzAtYTFkNi00NjNhOGU5Mjg3
+        OTcvIiwgInRhc2tfaWQiOiAiZjYzZmFhM2MtM2QxZC00MTMwLWExZDYtNDYz
+        YThlOTI4Nzk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoxOVoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoxOVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmNDkzNTI3ZDQzY2UzYTZjM2VhOSJ9
+        LCAiaWQiOiAiNTZhY2Y0OTM1MjdkNDNjZTNhNmMzZWE5In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:19 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
+        description."}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '97'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '310'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
+        description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
+        [], "_id": {"$oid": "56acf7bf17f25e2e6d2d23b1"}, "id": "integration_test_repository_group",
+        "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:51 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Encoding:
+      - utf-8
+      Content-Length:
+      - '452'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:51 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_id"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "56acf7bf17f25e2e6d2d23b2"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:51 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/associate/
+    body:
+      encoding: US-ASCII
+      string: ! '{"criteria":{"filters":{"id":{"$in":["integration_test_id"]}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '63'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '23'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '["integration_test_id"]'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:51 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: 'null'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:51 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/5f6f2f01-7784-4881-83cd-1ba25be2e7ff/",
+        "task_id": "5f6f2f01-7784-4881-83cd-1ba25be2e7ff"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:51 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/5f6f2f01-7784-4881-83cd-1ba25be2e7ff/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ZjZmMmYwMS03Nzg0LTQ4ODEtODNjZC0xYmEyNWJlMmU3
+        ZmYvIiwgInRhc2tfaWQiOiAiNWY2ZjJmMDEtNzc4NC00ODgxLTgzY2QtMWJh
+        MjViZTJlN2ZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1MVoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1MVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmN2JmNTI3ZDQzY2UzYTZjM2VhZiJ9
+        LCAiaWQiOiAiNTZhY2Y3YmY1MjdkNDNjZTNhNmMzZWFmIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:51 GMT
 recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_create/create.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_create/create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
     body:
       encoding: US-ASCII
       string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
@@ -24,13 +24,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
+      - Sat, 30 Jan 2016 17:49:51 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '310'
       Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
       Connection:
       - close
       Content-Type:
@@ -39,13 +39,13 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
         description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
-        [], "_id": {"$oid": "56aba1b6de040332a523ca4b"}, "id": "integration_test_repository_group",
+        [], "_id": {"$oid": "56acf7bf17f25e2e6e83a082"}, "id": "integration_test_repository_group",
         "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:51 GMT
 - request:
     method: delete
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
+      - Sat, 30 Jan 2016 17:49:52 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -77,5 +77,5 @@ http_interactions:
       encoding: US-ASCII
       string: 'null'
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:52 GMT
 recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_destroy/destroy.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_destroy/destroy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
     body:
       encoding: US-ASCII
       string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
@@ -24,13 +24,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
+      - Sat, 30 Jan 2016 17:49:52 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '310'
       Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
       Connection:
       - close
       Content-Type:
@@ -39,13 +39,13 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
         description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
-        [], "_id": {"$oid": "56aba1b6de040332a523ca4c"}, "id": "integration_test_repository_group",
+        [], "_id": {"$oid": "56acf7c017f25e2e6e83a083"}, "id": "integration_test_repository_group",
         "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:52 GMT
 - request:
     method: delete
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
+      - Sat, 30 Jan 2016 17:49:52 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -77,5 +77,5 @@ http_interactions:
       encoding: US-ASCII
       string: 'null'
     http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
+  recorded_at: Sat, 30 Jan 2016 17:49:52 GMT
 recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors/retrieve_distributors.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors/retrieve_distributors.yml
@@ -1,0 +1,1130 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
+        description."}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '97'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 15:58:14 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '310'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
+        description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
+        [], "_id": {"$oid": "56acdd9617f25e2e6e83a01e"}, "id": "integration_test_repository_group",
+        "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 15:58:14 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"176e494ccb32cac59e6d"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:00:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "176e494ccb32cac59e6d"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acde1b17f25e2e6d2d236f"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:00:27 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/80aea5c5-bf15-4806-82f1-5342ca4ac113/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:00:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84MGFlYTVjNS1iZjE1LTQ4MDYtODJmMS01MzQyY2E0YWMx
+        MTMvIiwgInRhc2tfaWQiOiAiODBhZWE1YzUtYmYxNS00ODA2LTgyZjEtNTM0
+        MmNhNGFjMTEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjowMDoyN1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjowMDoyN1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNkZTFiNTI3ZDQzY2UzYTZjM2U3MiJ9
+        LCAiaWQiOiAiNTZhY2RlMWI1MjdkNDNjZTNhNmMzZTcyIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:00:28 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"cac90fedd541ec9ec000"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:00:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "cac90fedd541ec9ec000"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acde2d17f25e2e6f4ffd90"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:00:45 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/8ed88b1c-a275-484e-be22-ae4df9467428/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:00:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZWQ4OGIxYy1hMjc1LTQ4NGUtYmUyMi1hZTRkZjk0Njc0
+        MjgvIiwgInRhc2tfaWQiOiAiOGVkODhiMWMtYTI3NS00ODRlLWJlMjItYWU0
+        ZGY5NDY3NDI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjowMDo0NVoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjowMDo0NVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNkZTJkNTI3ZDQzY2UzYTZjM2U3NSJ9
+        LCAiaWQiOiAiNTZhY2RlMmQ1MjdkNDNjZTNhNmMzZTc1In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:00:46 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"f7dd0cd04da1009c6fbd"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:03:07 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "f7dd0cd04da1009c6fbd"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acdebb17f25e2e6f4ffd99"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:03:07 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/f6dc674d-de4e-410d-8883-1c338634132d/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:03:08 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mNmRjNjc0ZC1kZTRlLTQxMGQtODg4My0xYzMzODYzNDEz
+        MmQvIiwgInRhc2tfaWQiOiAiZjZkYzY3NGQtZGU0ZS00MTBkLTg4ODMtMWMz
+        Mzg2MzQxMzJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjowMzowN1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjowMzowN1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNkZWJiNTI3ZDQzY2UzYTZjM2U3OCJ9
+        LCAiaWQiOiAiNTZhY2RlYmI1MjdkNDNjZTNhNmMzZTc4In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:03:08 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"49b41acca09a04d56f19"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:10:36 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "49b41acca09a04d56f19"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56ace07d17f25e2e6e83a040"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:10:37 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/6771bcf0-a518-4b3a-b9ed-0ea7fa46c004/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:10:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82NzcxYmNmMC1hNTE4LTRiM2EtYjllZC0wZWE3ZmE0NmMw
+        MDQvIiwgInRhc2tfaWQiOiAiNjc3MWJjZjAtYTUxOC00YjNhLWI5ZWQtMGVh
+        N2ZhNDZjMDA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMDozN1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMDozN1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMDdkNTI3ZDQzY2UzYTZjM2U3ZCJ9
+        LCAiaWQiOiAiNTZhY2UwN2Q1MjdkNDNjZTNhNmMzZTdkIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:10:37 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"496f1fc9c6f27f4e4e75"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:12:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "496f1fc9c6f27f4e4e75"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56ace0f017f25e2e6f4ffda9"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:12:32 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/b651b599-a107-487e-925c-d8b62ad59f51/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:12:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iNjUxYjU5OS1hMTA3LTQ4N2UtOTI1Yy1kOGI2MmFkNTlm
+        NTEvIiwgInRhc2tfaWQiOiAiYjY1MWI1OTktYTEwNy00ODdlLTkyNWMtZDhi
+        NjJhZDU5ZjUxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMjozM1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMjozM1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMGYxNTI3ZDQzY2UzYTZjM2U4MSJ9
+        LCAiaWQiOiAiNTZhY2UwZjE1MjdkNDNjZTNhNmMzZTgxIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:12:33 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"5e2f5837d09d453847fe"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "5e2f5837d09d453847fe"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56ace11717f25e2e6d2d2382"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:11 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/381e0e1c-801f-4202-a276-07d6075aaee1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zODFlMGUxYy04MDFmLTQyMDItYTI3Ni0wN2Q2MDc1YWFl
+        ZTEvIiwgInRhc2tfaWQiOiAiMzgxZTBlMWMtODAxZi00MjAyLWEyNzYtMDdk
+        NjA3NWFhZWUxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMzoxMloiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMzoxMloi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMTE4NTI3ZDQzY2UzYTZjM2U4NSJ9
+        LCAiaWQiOiAiNTZhY2UxMTg1MjdkNDNjZTNhNmMzZTg1In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:12 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"5361df2eaf47919046c7"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "5361df2eaf47919046c7"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56ace12d17f25e2e6d2d238c"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:33 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/6b817403-9fd7-4501-9569-2ab5df4b85c6/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82YjgxNzQwMy05ZmQ3LTQ1MDEtOTU2OS0yYWI1ZGY0Yjg1
+        YzYvIiwgInRhc2tfaWQiOiAiNmI4MTc0MDMtOWZkNy00NTAxLTk1NjktMmFi
+        NWRmNGI4NWM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMzozM1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMzozM1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMTJkNTI3ZDQzY2UzYTZjM2U4OSJ9
+        LCAiaWQiOiAiNTZhY2UxMmQ1MjdkNDNjZTNhNmMzZTg5In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:33 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"aff56b471186d99f0a9c"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "aff56b471186d99f0a9c"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56ace15317f25e2e6d2d2396"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:11 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/3f349786-3d4f-4e6f-b030-3c8ce52d5817/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zZjM0OTc4Ni0zZDRmLTRlNmYtYjAzMC0zYzhjZTUyZDU4
+        MTcvIiwgInRhc2tfaWQiOiAiM2YzNDk3ODYtM2Q0Zi00ZTZmLWIwMzAtM2M4
+        Y2U1MmQ1ODE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxNDoxMVoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxNDoxMVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMTUzNTI3ZDQzY2UzYTZjM2U4ZCJ9
+        LCAiaWQiOiAiNTZhY2UxNTM1MjdkNDNjZTNhNmMzZThkIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:12 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"81140e9ef08c012a3382"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "81140e9ef08c012a3382"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56ace17317f25e2e6f4ffdc1"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:43 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Encoding:
+      - utf-8
+      Content-Length:
+      - '452'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:43 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_id"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "56ace17317f25e2e6f4ffdc3"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:43 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/distributors/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '439'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        W3sic2NyYXRjaHBhZCI6IG51bGwsICJyZXBvX2dyb3VwX2lkIjogImludGVn
+        cmF0aW9uX3Rlc3RfcmVwb3NpdG9yeV9ncm91cCIsICJfbnMiOiAicmVwb19n
+        cm91cF9kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX3R5cGVfaWQiOiAiZ3JvdXBfZXhwb3J0X2Rpc3RyaWJ1dG9y
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1NmFjZTE3MzE3ZjI1ZTJlNmY0ZmZkYzIi
+        fSwgImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiBmYWxzZX0s
+        ICJpZCI6ICI2M2YxMGUyMS0xYzQzLTQ3NjQtODY2ZS0zOTYwMmJmZGMwMDQi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9fZ3JvdXBzL2ludGVncmF0
+        aW9uX3Rlc3RfcmVwb3NpdG9yeV9ncm91cC9kaXN0cmlidXRvcnMvNjNmMTBl
+        MjEtMWM0My00NzY0LTg2NmUtMzk2MDJiZmRjMDA0LyJ9XQ==
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:43 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: 'null'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:43 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/27a21925-07e0-490e-826b-76c95d44adcf/",
+        "task_id": "27a21925-07e0-490e-826b-76c95d44adcf"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:43 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/27a21925-07e0-490e-826b-76c95d44adcf/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yN2EyMTkyNS0wN2UwLTQ5MGUtODI2Yi03NmM5NWQ0NGFk
+        Y2YvIiwgInRhc2tfaWQiOiAiMjdhMjE5MjUtMDdlMC00OTBlLTgyNmItNzZj
+        OTVkNDRhZGNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxNDo0M1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxNDo0M1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMTczNTI3ZDQzY2UzYTZjM2U5MSJ9
+        LCAiaWQiOiAiNTZhY2UxNzM1MjdkNDNjZTNhNmMzZTkxIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:44 GMT
+recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_and_publish.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_and_publish.yml
@@ -1,0 +1,395 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/publish/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"4a1fbbc6-eacf-4e78-a34e-5f78dbccf2ae"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/8eeaccef-4848-4b07-a4c9-36e2f7303449/",
+        "task_id": "8eeaccef-4848-4b07-a4c9-36e2f7303449"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:52 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/193949c6-2dc3-488b-a74b-5e5d50eb6461/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xOTM5NDljNi0yZGMzLTQ4OGItYTc0Yi01ZTVkNTBlYjY0
+        NjEvIiwgInRhc2tfaWQiOiAiMTkzOTQ5YzYtMmRjMy00ODhiLWE3NGItNWU1
+        ZDUwZWI2NDYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1M1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1M1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmN2MwNTI3ZDQzY2UzYTZjM2ViMSJ9
+        LCAiaWQiOiAiNTZhY2Y3YzA1MjdkNDNjZTNhNmMzZWIxIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:53 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"c37b8d7ee5fd94e817b1"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "c37b8d7ee5fd94e817b1"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acf7c117f25e2e6f4ffdea"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:53 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Encoding:
+      - utf-8
+      Content-Length:
+      - '452'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:53 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_id"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "56acf7c117f25e2e6f4ffdec"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:53 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/distributors/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '439'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        W3sic2NyYXRjaHBhZCI6IG51bGwsICJyZXBvX2dyb3VwX2lkIjogImludGVn
+        cmF0aW9uX3Rlc3RfcmVwb3NpdG9yeV9ncm91cCIsICJfbnMiOiAicmVwb19n
+        cm91cF9kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX3R5cGVfaWQiOiAiZ3JvdXBfZXhwb3J0X2Rpc3RyaWJ1dG9y
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1NmFjZjdjMTE3ZjI1ZTJlNmY0ZmZkZWIi
+        fSwgImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiBmYWxzZX0s
+        ICJpZCI6ICJkNDZlM2RhOS01ODFkLTRmM2YtYWRkOS04NTBmZDYzNTdkZTUi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9fZ3JvdXBzL2ludGVncmF0
+        aW9uX3Rlc3RfcmVwb3NpdG9yeV9ncm91cC9kaXN0cmlidXRvcnMvZDQ2ZTNk
+        YTktNTgxZC00ZjNmLWFkZDktODUwZmQ2MzU3ZGU1LyJ9XQ==
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:53 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: 'null'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:53 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/0e109eea-ac1b-4cf9-8a80-9150fb97a83b/",
+        "task_id": "0e109eea-ac1b-4cf9-8a80-9150fb97a83b"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:53 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/0e109eea-ac1b-4cf9-8a80-9150fb97a83b/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wZTEwOWVlYS1hYzFiLTRjZjktOGE4MC05MTUwZmI5N2E4
+        M2IvIiwgInRhc2tfaWQiOiAiMGUxMDllZWEtYWMxYi00Y2Y5LThhODAtOTE1
+        MGZiOTdhODNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1M1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1M1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmN2MxNTI3ZDQzY2UzYTZjM2ViMiJ9
+        LCAiaWQiOiAiNTZhY2Y3YzE1MjdkNDNjZTNhNmMzZWIyIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:54 GMT
+recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_and_publish/publish.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_and_publish/publish.yml
@@ -1,0 +1,753 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"218204ae2bc1524a705e"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:25:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "218204ae2bc1524a705e"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56ace40e17f25e2e6e83a062"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:25:50 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/publish/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"a5862814-463d-4ca1-9ece-519b1602bf89"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:25:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/8f071419-9b04-4488-8f22-c9644bf05d4e/",
+        "task_id": "8f071419-9b04-4488-8f22-c9644bf05d4e"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:25:51 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/e01500fe-c8bd-4edc-bf73-33f1100ec1b6/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:25:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9lMDE1MDBmZS1jOGJkLTRlZGMtYmY3My0zM2YxMTAwZWMx
+        YjYvIiwgInRhc2tfaWQiOiAiZTAxNTAwZmUtYzhiZC00ZWRjLWJmNzMtMzNm
+        MTEwMGVjMWI2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoyNTo1MVoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoyNTo1MVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlNDBmNTI3ZDQzY2UzYTZjM2U5NyJ9
+        LCAiaWQiOiAiNTZhY2U0MGY1MjdkNDNjZTNhNmMzZTk3In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:25:51 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"64a89d7ab8754b1d5dec"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:51:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "64a89d7ab8754b1d5dec"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acea0817f25e2e6f4ffdd1"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:51:20 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/publish/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"b3f93a4f-a3dd-419f-9062-880717b3b80d"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:51:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/da08a983-7037-45bc-b9c9-ab44a71b23d7/",
+        "task_id": "da08a983-7037-45bc-b9c9-ab44a71b23d7"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:51:21 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/c358a064-3baa-4571-9b40-0b74170c954f/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:51:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jMzU4YTA2NC0zYmFhLTQ1NzEtOWI0MC0wYjc0MTcwYzk1
+        NGYvIiwgInRhc2tfaWQiOiAiYzM1OGEwNjQtM2JhYS00NTcxLTliNDAtMGI3
+        NDE3MGM5NTRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjo1MToyMVoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjo1MToyMVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlYTA5NTI3ZDQzY2UzYTZjM2U5ZCJ9
+        LCAiaWQiOiAiNTZhY2VhMDk1MjdkNDNjZTNhNmMzZTlkIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:51:21 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"5670c77c3fec06e63a2a"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:34:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "5670c77c3fec06e63a2a"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acf42017f25e2e6e83a073"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:34:24 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/publish/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"667baefd-6427-48c9-9192-12404b356eb1"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:34:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/9c7aaa54-bf3c-401f-949d-45970b01c006/",
+        "task_id": "9c7aaa54-bf3c-401f-949d-45970b01c006"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:34:24 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/ea7c954b-db9b-4789-a271-fc33e68475f6/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:34:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9lYTdjOTU0Yi1kYjliLTQ3ODktYTI3MS1mYzMzZTY4NDc1
+        ZjYvIiwgInRhc2tfaWQiOiAiZWE3Yzk1NGItZGI5Yi00Nzg5LWEyNzEtZmMz
+        M2U2ODQ3NWY2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNDoyNFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNDoyNFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmNDIwNTI3ZDQzY2UzYTZjM2VhNSJ9
+        LCAiaWQiOiAiNTZhY2Y0MjA1MjdkNDNjZTNhNmMzZWE1In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:34:25 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"583765b95eb0e9d5bbd1"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "583765b95eb0e9d5bbd1"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acf49417f25e2e6f4ffde1"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:20 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Encoding:
+      - utf-8
+      Content-Length:
+      - '452'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:20 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_id"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "56acf49417f25e2e6f4ffde3"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:20 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/distributors/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '439'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        W3sic2NyYXRjaHBhZCI6IG51bGwsICJyZXBvX2dyb3VwX2lkIjogImludGVn
+        cmF0aW9uX3Rlc3RfcmVwb3NpdG9yeV9ncm91cCIsICJfbnMiOiAicmVwb19n
+        cm91cF9kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX3R5cGVfaWQiOiAiZ3JvdXBfZXhwb3J0X2Rpc3RyaWJ1dG9y
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1NmFjZjQ5NDE3ZjI1ZTJlNmY0ZmZkZTIi
+        fSwgImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiBmYWxzZX0s
+        ICJpZCI6ICI3NDNmODkxNi05MzEyLTRiNmQtOGYyMS1mOWVkMGIxMDk1ZWMi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9fZ3JvdXBzL2ludGVncmF0
+        aW9uX3Rlc3RfcmVwb3NpdG9yeV9ncm91cC9kaXN0cmlidXRvcnMvNzQzZjg5
+        MTYtOTMxMi00YjZkLThmMjEtZjllZDBiMTA5NWVjLyJ9XQ==
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:20 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/publish/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"743f8916-9312-4b6d-8f21-f9ed0b1095ec"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/dc2d00b1-90cb-479c-b8c5-943cda46720e/",
+        "task_id": "dc2d00b1-90cb-479c-b8c5-943cda46720e"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:20 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: 'null'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:20 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/faa4af7b-1d8b-41a4-bbcd-aa79174c193f/",
+        "task_id": "faa4af7b-1d8b-41a4-bbcd-aa79174c193f"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:20 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/faa4af7b-1d8b-41a4-bbcd-aa79174c193f/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mYWE0YWY3Yi0xZDhiLTQxYTQtYmJjZC1hYTc5MTc0YzE5
+        M2YvIiwgInRhc2tfaWQiOiAiZmFhNGFmN2ItMWQ4Yi00MWE0LWJiY2QtYWE3
+        OTE3NGMxOTNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoyMFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoyMFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmNDk0NTI3ZDQzY2UzYTZjM2VhYiJ9
+        LCAiaWQiOiAiNTZhY2Y0OTQ1MjdkNDNjZTNhNmMzZWFiIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:21 GMT
+recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_and_publish/retrieve_distributors.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_and_publish/retrieve_distributors.yml
@@ -1,0 +1,597 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"ac95c7edd030947b96f2"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:25:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "ac95c7edd030947b96f2"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56ace40d17f25e2e6f4ffdcb"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:25:49 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/006fe1bd-2b20-4cec-850a-4f9103d01848/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:25:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wMDZmZTFiZC0yYjIwLTRjZWMtODUwYS00ZjkxMDNkMDE4
+        NDgvIiwgInRhc2tfaWQiOiAiMDA2ZmUxYmQtMmIyMC00Y2VjLTg1MGEtNGY5
+        MTAzZDAxODQ4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoyNTo1MFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoyNTo1MFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlNDBlNTI3ZDQzY2UzYTZjM2U5NSJ9
+        LCAiaWQiOiAiNTZhY2U0MGU1MjdkNDNjZTNhNmMzZTk1In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:25:50 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"c82b3094b4f9307dd01c"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:51:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "c82b3094b4f9307dd01c"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acea0917f25e2e6f4ffdd4"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:51:21 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/f4fd0417-7af4-4e4f-b494-c3c8bce005c7/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:51:22 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mNGZkMDQxNy03YWY0LTRlNGYtYjQ5NC1jM2M4YmNlMDA1
+        YzcvIiwgInRhc2tfaWQiOiAiZjRmZDA0MTctN2FmNC00ZTRmLWI0OTQtYzNj
+        OGJjZTAwNWM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjo1MToyMloiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjo1MToyMloi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlYTBhNTI3ZDQzY2UzYTZjM2U5ZSJ9
+        LCAiaWQiOiAiNTZhY2VhMGE1MjdkNDNjZTNhNmMzZTllIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:51:22 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"6aad4ce30df0ed3ca203"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:34:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "6aad4ce30df0ed3ca203"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acf42117f25e2e6e83a075"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:34:25 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/47104bf8-d53c-46dd-9dff-e1e193caffb1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:34:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80NzEwNGJmOC1kNTNjLTQ2ZGQtOWRmZi1lMWUxOTNjYWZm
+        YjEvIiwgInRhc2tfaWQiOiAiNDcxMDRiZjgtZDUzYy00NmRkLTlkZmYtZTFl
+        MTkzY2FmZmIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNDoyNVoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNDoyNVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmNDIxNTI3ZDQzY2UzYTZjM2VhNiJ9
+        LCAiaWQiOiAiNTZhY2Y0MjE1MjdkNDNjZTNhNmMzZWE2In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:34:26 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo_w_distributor","description":"Test
+        description.","distributors":[{"http":false,"https":false,"distributor_type_id":"group_export_distributor","distributor_config":{"http":false,"https":false},"auto_publish":false,"id":"551fb7424dc25a3276fc"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '514'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo_w_distributor", "description":
+        "Test description.", "distributors": [{"http": false, "distributor_config":
+        {"http": false, "https": false}, "auto_publish": false, "distributor_type_id":
+        "group_export_distributor", "https": false, "id": "551fb7424dc25a3276fc"}],
+        "_ns": "repo_groups", "notes": {}, "repo_ids": [], "_id": {"$oid": "56acf49517f25e2e6f4ffde4"},
+        "id": "integration_test_repository_group", "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:21 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Encoding:
+      - utf-8
+      Content-Length:
+      - '452'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:21 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_id"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "56acf49517f25e2e6f4ffde6"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:21 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/distributors/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '439'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        W3sic2NyYXRjaHBhZCI6IG51bGwsICJyZXBvX2dyb3VwX2lkIjogImludGVn
+        cmF0aW9uX3Rlc3RfcmVwb3NpdG9yeV9ncm91cCIsICJfbnMiOiAicmVwb19n
+        cm91cF9kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX3R5cGVfaWQiOiAiZ3JvdXBfZXhwb3J0X2Rpc3RyaWJ1dG9y
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1NmFjZjQ5NTE3ZjI1ZTJlNmY0ZmZkZTUi
+        fSwgImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiBmYWxzZX0s
+        ICJpZCI6ICI0YTBjYzg1YS00YTY2LTQwZTYtODZiZi05YzQxZTQyZThkYWEi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9fZ3JvdXBzL2ludGVncmF0
+        aW9uX3Rlc3RfcmVwb3NpdG9yeV9ncm91cC9kaXN0cmlidXRvcnMvNGEwY2M4
+        NWEtNGE2Ni00MGU2LTg2YmYtOWM0MWU0MmU4ZGFhLyJ9XQ==
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:21 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: 'null'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:21 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/8e1411fb-d3df-4004-b476-589e1ab34c4f/",
+        "task_id": "8e1411fb-d3df-4004-b476-589e1ab34c4f"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:21 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/8e1411fb-d3df-4004-b476-589e1ab34c4f/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:22 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZTE0MTFmYi1kM2RmLTQwMDQtYjQ3Ni01ODllMWFiMzRj
+        NGYvIiwgInRhc2tfaWQiOiAiOGUxNDExZmItZDNkZi00MDA0LWI0NzYtNTg5
+        ZTFhYjM0YzRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoyMVoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoyMVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmNDk1NTI3ZDQzY2UzYTZjM2VhYyJ9
+        LCAiaWQiOiAiNTZhY2Y0OTU1MjdkNDNjZTNhNmMzZWFjIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:22 GMT
+recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_empty/retrieve_distributors.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_empty/retrieve_distributors.yml
@@ -1,0 +1,448 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/8a446ec9-ecf5-4ad0-8f80-3856e1384564/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:03:09 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84YTQ0NmVjOS1lY2Y1LTRhZDAtOGY4MC0zODU2ZTEzODQ1
+        NjQvIiwgInRhc2tfaWQiOiAiOGE0NDZlYzktZWNmNS00YWQwLThmODAtMzg1
+        NmUxMzg0NTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjowMzowOFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjowMzowOFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNkZWJjNTI3ZDQzY2UzYTZjM2U3OSJ9
+        LCAiaWQiOiAiNTZhY2RlYmM1MjdkNDNjZTNhNmMzZTc5In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:03:09 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/a119ec1c-59ce-4a51-b49f-238c92ccaf74/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:10:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hMTE5ZWMxYy01OWNlLTRhNTEtYjQ5Zi0yMzhjOTJjY2Fm
+        NzQvIiwgInRhc2tfaWQiOiAiYTExOWVjMWMtNTljZS00YTUxLWI0OWYtMjM4
+        YzkyY2NhZjc0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMDozOFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMDozOFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMDdlNTI3ZDQzY2UzYTZjM2U3ZSJ9
+        LCAiaWQiOiAiNTZhY2UwN2U1MjdkNDNjZTNhNmMzZTdlIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:10:38 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/b0c102e2-8480-4c9c-b594-5cad35d48f36/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:12:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMGMxMDJlMi04NDgwLTRjOWMtYjU5NC01Y2FkMzVkNDhm
+        MzYvIiwgInRhc2tfaWQiOiAiYjBjMTAyZTItODQ4MC00YzljLWI1OTQtNWNh
+        ZDM1ZDQ4ZjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMjozNFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMjozNFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMGYyNTI3ZDQzY2UzYTZjM2U4MiJ9
+        LCAiaWQiOiAiNTZhY2UwZjI1MjdkNDNjZTNhNmMzZTgyIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:12:34 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
+        description."}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '97'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '310'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
+        description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
+        [], "_id": {"$oid": "56ace11817f25e2e6d2d2385"}, "id": "integration_test_repository_group",
+        "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:12 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Encoding:
+      - utf-8
+      Content-Length:
+      - '452'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:12 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_id"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "56ace11817f25e2e6d2d2386"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:12 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/distributors/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '[]'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:13 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: 'null'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:13 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/438262df-69a7-4cf3-a88d-03d2702f1bd0/",
+        "task_id": "438262df-69a7-4cf3-a88d-03d2702f1bd0"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:13 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/438262df-69a7-4cf3-a88d-03d2702f1bd0/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80MzgyNjJkZi02OWE3LTRjZjMtYTg4ZC0wM2QyNzAyZjFi
+        ZDAvIiwgInRhc2tfaWQiOiAiNDM4MjYyZGYtNjlhNy00Y2YzLWE4OGQtMDNk
+        MjcwMmYxYmQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMzoxM1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMzoxM1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMTE5NTI3ZDQzY2UzYTZjM2U4NiJ9
+        LCAiaWQiOiAiNTZhY2UxMTk1MjdkNDNjZTNhNmMzZTg2In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:13 GMT
+recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_empty/retrieve_distributors_empty.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_retrieve_distributors_empty/retrieve_distributors_empty.yml
@@ -1,0 +1,660 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/71e0fabf-41c5-4641-ba02-d7e7114038e1/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:13:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83MWUwZmFiZi00MWM1LTQ2NDEtYmEwMi1kN2U3MTE0MDM4
+        ZTEvIiwgInRhc2tfaWQiOiAiNzFlMGZhYmYtNDFjNS00NjQxLWJhMDItZDdl
+        NzExNDAzOGUxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMzozNFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxMzozNFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMTJlNTI3ZDQzY2UzYTZjM2U4YSJ9
+        LCAiaWQiOiAiNTZhY2UxMmU1MjdkNDNjZTNhNmMzZThhIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:13:34 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/badb872a-604b-4af7-8af9-d03a2a8a91e8/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iYWRiODcyYS02MDRiLTRhZjctOGFmOS1kMDNhMmE4YTkx
+        ZTgvIiwgInRhc2tfaWQiOiAiYmFkYjg3MmEtNjA0Yi00YWY3LThhZjktZDAz
+        YTJhOGE5MWU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxNDoxMloiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxNDoxMloi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMTU0NTI3ZDQzY2UzYTZjM2U4ZSJ9
+        LCAiaWQiOiAiNTZhY2UxNTQ1MjdkNDNjZTNhNmMzZThlIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:13 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/564664ae-6d5d-42d9-ac14-c9ee444d06c6/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:14:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjQ2NjRhZS02ZDVkLTQyZDktYWMxNC1jOWVlNDQ0ZDA2
+        YzYvIiwgInRhc2tfaWQiOiAiNTY0NjY0YWUtNmQ1ZC00MmQ5LWFjMTQtYzll
+        ZTQ0NGQwNmM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxNDo0NFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoxNDo0NFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlMTc0NTI3ZDQzY2UzYTZjM2U5MiJ9
+        LCAiaWQiOiAiNTZhY2UxNzQ1MjdkNDNjZTNhNmMzZTkyIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:14:45 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/cf245cf7-b690-4606-a37b-b2dd82cb97bc/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:25:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZjI0NWNmNy1iNjkwLTQ2MDYtYTM3Yi1iMmRkODJjYjk3
+        YmMvIiwgInRhc2tfaWQiOiAiY2YyNDVjZjctYjY5MC00NjA2LWEzN2ItYjJk
+        ZDgyY2I5N2JjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoyNTo1MloiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjoyNTo1Mloi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlNDEwNTI3ZDQzY2UzYTZjM2U5OCJ9
+        LCAiaWQiOiAiNTZhY2U0MTA1MjdkNDNjZTNhNmMzZTk4In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:25:52 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/cb83ace3-96e9-48f7-9942-5791b8354e54/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 16:51:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jYjgzYWNlMy05NmU5LTQ4ZjctOTk0Mi01NzkxYjgzNTRl
+        NTQvIiwgInRhc2tfaWQiOiAiY2I4M2FjZTMtOTZlOS00OGY3LTk5NDItNTc5
+        MWI4MzU0ZTU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjo1MToyM1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNjo1MToyM1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNlYTBiNTI3ZDQzY2UzYTZjM2U5ZiJ9
+        LCAiaWQiOiAiNTZhY2VhMGI1MjdkNDNjZTNhNmMzZTlmIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 16:51:23 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/52206378-640f-48f0-bd03-70670e85c03b/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:34:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81MjIwNjM3OC02NDBmLTQ4ZjAtYmQwMy03MDY3MGU4NWMw
+        M2IvIiwgInRhc2tfaWQiOiAiNTIyMDYzNzgtNjQwZi00OGYwLWJkMDMtNzA2
+        NzBlODVjMDNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNDoyNloiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNDoyNloi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmNDIyNTI3ZDQzY2UzYTZjM2VhNyJ9
+        LCAiaWQiOiAiNTZhY2Y0MjI1MjdkNDNjZTNhNmMzZWE3In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:34:27 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/e1e704bb-a72b-479e-a7fe-b63077ba0dc8/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9lMWU3MDRiYi1hNzJiLTQ3OWUtYTdmZS1iNjMwNzdiYTBk
+        YzgvIiwgInRhc2tfaWQiOiAiZTFlNzA0YmItYTcyYi00NzllLWE3ZmUtYjYz
+        MDc3YmEwZGM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoyMloiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoyMloi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmNDk2NTI3ZDQzY2UzYTZjM2VhZCJ9
+        LCAiaWQiOiAiNTZhY2Y0OTY1MjdkNDNjZTNhNmMzZWFkIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:23 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
+        description."}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '97'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '310'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
+        description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
+        [], "_id": {"$oid": "56acf7c217f25e2e6f4ffded"}, "id": "integration_test_repository_group",
+        "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:54 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Encoding:
+      - utf-8
+      Content-Length:
+      - '452'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:54 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_id"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "56acf7c217f25e2e6e83a086"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:54 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/distributors/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '[]'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:54 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: 'null'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:54 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/3237f530-a555-4737-8349-d459648a5c58/",
+        "task_id": "3237f530-a555-4737-8349-d459648a5c58"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:54 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/3237f530-a555-4737-8349-d459648a5c58/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMjM3ZjUzMC1hNTU1LTQ3MzctODM0OS1kNDU5NjQ4YTVj
+        NTgvIiwgInRhc2tfaWQiOiAiMzIzN2Y1MzAtYTU1NS00NzM3LTgzNDktZDQ1
+        OTY0OGE1YzU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1NFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1NFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmN2MyNTI3ZDQzY2UzYTZjM2ViMyJ9
+        LCAiaWQiOiAiNTZhY2Y3YzI1MjdkNDNjZTNhNmMzZWIzIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:55 GMT
+recorded_with: VCR 3.0.1

--- a/test/fixtures/vcr_cassettes/resources/repo_group_unassociate/unassociate.yml
+++ b/test/fixtures/vcr_cassettes/resources/repo_group_unassociate/unassociate.yml
@@ -396,278 +396,6 @@ http_interactions:
     http_version: 
   recorded_at: Fri, 29 Jan 2016 17:07:55 GMT
 - request:
-    method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/
-    body:
-      encoding: US-ASCII
-      string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
-        description."}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '97'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '310'
-      Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
-        description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
-        [], "_id": {"$oid": "56aba1b6de040332a523ca4d"}, "id": "integration_test_repository_group",
-        "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
-- request:
-    method: get
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: NOT FOUND
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '452'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
-        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
-        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
-        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
-        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
-- request:
-    method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: US-ASCII
-      string: ! '{"id":"integration_test_id"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '28'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '319'
-      Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repositories/integration_test_id/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
-        {}, "_ns": "repos", "_id": {"$oid": "56aba1b6de040332a476fc31"}, "id": "integration_test_id",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
-- request:
-    method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/associate/
-    body:
-      encoding: US-ASCII
-      string: ! '{"criteria":{"filters":{"id":{"$in":["integration_test_id"]}}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '63'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '23'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '["integration_test_id"]'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
-- request:
-    method: post
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/unassociate/
-    body:
-      encoding: US-ASCII
-      string: ! '{"criteria":{"filters":{"id":{"$in":["integration_test_id"]}}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '63'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '[]'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
-- request:
-    method: delete
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '4'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: 'null'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
-- request:
-    method: delete
-    uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Fri, 29 Jan 2016 17:30:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/fbd0b0eb-2e11-4794-9acb-249317432df1/",
-        "task_id": "fbd0b0eb-2e11-4794-9acb-249317432df1"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Fri, 29 Jan 2016 17:30:30 GMT
-- request:
     method: get
     uri: https://admin:icizRXdtWXs66PqkAXytGFMconvzbE8w@katello-yoda.example.com/pulp/api/v2/tasks/fbd0b0eb-2e11-4794-9acb-249317432df1/
     body:
@@ -720,4 +448,382 @@ http_interactions:
         ZTA5NzQxZGQ2NDBkNjA4In0=
     http_version: 
   recorded_at: Fri, 29 Jan 2016 17:30:31 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/48db1a43-8488-4305-bfe2-ba3378b633cd/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:36:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80OGRiMWE0My04NDg4LTQzMDUtYmZlMi1iYTMzNzhiNjMz
+        Y2QvIiwgInRhc2tfaWQiOiAiNDhkYjFhNDMtODQ4OC00MzA1LWJmZTItYmEz
+        Mzc4YjYzM2NkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoyM1oiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzozNjoyM1oi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmNDk3NTI3ZDQzY2UzYTZjM2VhZSJ9
+        LCAiaWQiOiAiNTZhY2Y0OTc1MjdkNDNjZTNhNmMzZWFlIn0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:36:24 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_repository_group","display_name":"foo","description":"Test
+        description."}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '97'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '310'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": null, "display_name": "foo", "description": "Test
+        description.", "distributors": [], "_ns": "repo_groups", "notes": {}, "repo_ids":
+        [], "_id": {"$oid": "56acf7c317f25e2e6e83a087"}, "id": "integration_test_repository_group",
+        "_href": "/pulp/api/v2/repo_groups/integration_test_repository_group/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:55 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Encoding:
+      - utf-8
+      Content-Length:
+      - '452'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"http_request_method": "GET", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:55 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":"integration_test_id"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '28'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "56acf7c317f25e2e6e83a088"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:55 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/associate/
+    body:
+      encoding: US-ASCII
+      string: ! '{"criteria":{"filters":{"id":{"$in":["integration_test_id"]}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '63'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '23'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '["integration_test_id"]'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:55 GMT
+- request:
+    method: post
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/actions/unassociate/
+    body:
+      encoding: US-ASCII
+      string: ! '{"criteria":{"filters":{"id":{"$in":["integration_test_id"]}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '63'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '[]'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:55 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repo_groups/integration_test_repository_group/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: 'null'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:55 GMT
+- request:
+    method: delete
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: US-ASCII
+      string: ! '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/d3686e29-ae8f-4eb2-abf8-8294ca9feacc/",
+        "task_id": "d3686e29-ae8f-4eb2-abf8-8294ca9feacc"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:55 GMT
+- request:
+    method: get
+    uri: https://admin:hAauH9UJY8NwtTZvkWeYDWEeR3YpZVH3@katello-centos7-devel.example.com/pulp/api/v2/tasks/d3686e29-ae8f-4eb2-abf8-8294ca9feacc/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 30 Jan 2016 17:49:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzY4NmUyOS1hZThmLTRlYjItYWJmOC04Mjk0Y2E5ZmVh
+        Y2MvIiwgInRhc2tfaWQiOiAiZDM2ODZlMjktYWU4Zi00ZWIyLWFiZjgtODI5
+        NGNhOWZlYWNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTppbnRlZ3Jh
+        dGlvbl90ZXN0X2lkIiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1NVoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMS0zMFQxNzo0OTo1NVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInBy
+        b2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
+        bC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YWNmN2MzNTI3ZDQzY2UzYTZjM2ViNCJ9
+        LCAiaWQiOiAiNTZhY2Y3YzM1MjdkNDNjZTNhNmMzZWI0In0=
+    http_version: 
+  recorded_at: Sat, 30 Jan 2016 17:49:56 GMT
 recorded_with: VCR 3.0.1

--- a/test/models/group_export_distributor_test.rb
+++ b/test/models/group_export_distributor_test.rb
@@ -1,0 +1,23 @@
+require 'rubygems'
+require 'minitest/autorun'
+
+require './lib/runcible'
+
+class GroupExportDistributorTest < MiniTest::Unit::TestCase
+  def setup
+    @dist = Runcible::Models::GroupExportDistributor.new(true, true)
+  end
+
+  def test_config
+    assert_equal(true, @dist.config["http"])
+    assert_equal(true, @dist.config["https"])
+    # NB: setting distributor_type_id and distributor_config saves a couple of API
+    # calls when creating repos.
+    assert_equal('group_export_distributor', @dist.config["distributor_type_id"])
+    assert_equal({:http => true, :https => true}, @dist.config["distributor_config"])
+  end
+
+  def test_type_id
+    assert_equal('group_export_distributor', @dist.type_id)
+  end
+end


### PR DESCRIPTION
These two commits allow for passing through the `relative_url` parameter on export, as well as publishing of group exports.

VCR tests have been partially re-recorded to account for the new API calls to Pulp.