### PR TITLE
fixes #13512 - docker v2 - pulp 2.8 - add support for tag content unit

### DIFF
--- a/lib/runcible/extensions/docker_tag.rb
+++ b/lib/runcible/extensions/docker_tag.rb
@@ -1,0 +1,9 @@
+module Runcible
+  module Extensions
+    class DockerTag < Runcible::Extensions::Unit
+      def self.content_type
+        'docker_tag'
+      end
+    end
+  end
+end

--- a/lib/runcible/extensions/repository.rb
+++ b/lib/runcible/extensions/repository.rb
@@ -260,6 +260,26 @@ module Runcible
         unit_search(id, criteria).map { |i| i['metadata'].with_indifferent_access }
       end
 
+      # Retrieves the docker tag IDs for a single repository
+      #
+      # @param  [String]                id the ID of the repository
+      # @return [RestClient::Response]  the set of repository docker tag IDs
+      def docker_tag_ids(id)
+        criteria = {:type_ids => [Runcible::Extensions::DockerTag.content_type],
+                    :fields => {:unit => [], :association => ['unit_id']}}
+
+        unit_search(id, criteria).map { |i| i['unit_id'] }
+      end
+
+      # Retrieves the docker tags for a single repository
+      #
+      # @param  [String]                id the ID of the repository
+      # @return [RestClient::Response]  the set of repository docker tags
+      def docker_tags(id)
+        criteria = {:type_ids => [Runcible::Extensions::DockerTag.content_type]}
+        unit_search(id, criteria).map { |i| i['metadata'].with_indifferent_access }
+      end
+
       # Retrieves the docker image IDs for a single repository
       #
       # @param  [String]                id the ID of the repository


### PR DESCRIPTION
NOTE: THIS CHANGE IS BASED ON PULP 2.8

With the pulp 2.8 support for docker v2, the docker tag implementation
has been updated to be a content type, similar to manifest, rpm...etc.
This commit adds that unit.

Tests for this unit will be added as part of http://projects.theforeman.org/issues/8102.