### PR TITLE
Fixes #15728 - Fixing code after json 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :test do
   gem 'mocha', "~> 0.14.0"
   gem 'rubocop', "0.39.0"
   gem 'coveralls'
+  gem 'pry'
 end

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -3,6 +3,7 @@ require 'minitest/autorun'
 require 'minitest/mock'
 require './lib/runcible/base'
 require './test/support/logger_support'
+require 'mocha'
 
 module Base
   class TestBase < MiniTest::Unit::TestCase
@@ -38,6 +39,23 @@ module Base
       data = @my_runcible.process_response(response)
 
       assert_equal 'Test body', data.body
+    end
+
+    def test_process_response_with_null
+      response = OpenStruct.new(:body => 'null')
+      data = @my_runcible.process_response(response)
+
+      assert_equal '', data.body
+    end
+
+    def test_process_response_wont_parse_boolean
+      # if body is parsed into a boolean, it can't be used as a
+      # RestClient::Response since rest-client attempts to extend and alter the
+      # value (which is frozen)
+      response = OpenStruct.new(:body => 'true')
+      data = @my_runcible.process_response(response)
+
+      assert_equal 'true', data.body
     end
 
     def test_verbose_logger


### PR DESCRIPTION
With the 2.0 release of the json gem, JSON.parse('true') started to
return true instead of throwing JSON::ParserError (which is technically
correct).

However, we send 'body' to RestClient::Response.create which attempts to
extend and modify the body (see https://git.io/vKoeh) which isn't
allowed for true (as it's a frozen value) so instead we now just use the
body ('true') instead of the actual parsed value if the body is not a
Hash or Array.
