### PR TITLE
fixes #18993 - Set depth for ostree distributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Exposing Pulp's juiciest parts. http://www.pulpproject.org/
 
-Latest Live Tested Version: **pulp-server-2.11.0-1.el7.noarch**
+Latest Live Tested Version: **pulp-server-2.12.1-1.el7.noarch**
 
 Current stable Runcible: https://github.com/Katello/runcible/tree/0.3
 

--- a/lib/runcible/models/ostree_distributor.rb
+++ b/lib/runcible/models/ostree_distributor.rb
@@ -4,7 +4,7 @@ require 'securerandom'
 module Runcible
   module Models
     class OstreeDistributor < Distributor
-      attr_accessor 'ostree_publish_directory', 'relative_path'
+      attr_accessor 'ostree_publish_directory', 'relative_path', 'depth'
 
       def initialize(params = {})
         super(params)

--- a/test/extensions/ostree_repository_test.rb
+++ b/test/extensions/ostree_repository_test.rb
@@ -83,17 +83,20 @@ module Extensions
     end
 
     def test_create_with_importer_and_distributors_objects
-      distributors = [Runcible::Models::OstreeDistributor.new(:id => '123')]
+      distributor_depth = -1
+      distributors = [Runcible::Models::OstreeDistributor.new(:id => '123', :depth => distributor_depth)]
       importer = Runcible::Models::OstreeImporter.new
-      depth = -1
-      importer.depth = depth
+      importer_depth = 4
+      importer.depth = importer_depth
       response = @extension.create_with_importer_and_distributors(RepositorySupport.repo_id, importer, distributors)
       assert_equal 201, response.code
 
       response = @extension.retrieve(RepositorySupport.repo_id, :details => true)
       assert_equal RepositorySupport.repo_id, response['id']
       assert_equal 'ostree_web_importer', response['importers'].first['importer_type_id']
-      assert_equal depth, response['importers'].first['config']['depth']
+      assert_equal importer_depth, response['importers'].first['config']['depth']
+      assert_equal 'ostree_web_distributor', response['distributors'].first['distributor_type_id']
+      assert_equal distributor_depth, response['distributors'].first['config']['depth']
     end
   end
 

--- a/test/fixtures/vcr_cassettes/extensions/ostree_branch_repository_unit_list/ostree_branch_ids.yml
+++ b/test/fixtures/vcr_cassettes/extensions/ostree_branch_repository_unit_list/ostree_branch_ids.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Feb 2017 12:30:49 GMT
+      - Thu, 23 Mar 2017 05:16:57 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -36,11 +36,11 @@ http_interactions:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
-      string: '[{"metadata": {"_id": "8f958529-8425-4a97-befd-3283e77665be", "_content_type_id":
-        "ostree"}, "_id": {"$oid": "5891d4f94b92d9e3004e81da"}, "unit_id": "8f958529-8425-4a97-befd-3283e77665be",
-        "unit_type_id": "ostree"}, {"metadata": {"_id": "f3f067ea-2fd6-40b3-b138-cc28117063ed",
-        "_content_type_id": "ostree"}, "_id": {"$oid": "5891d4f94b92d9e3004e81d9"},
-        "unit_id": "f3f067ea-2fd6-40b3-b138-cc28117063ed", "unit_type_id": "ostree"}]'
+      string: '[{"metadata": {"_id": "16cc5bbf-699c-4c42-add5-422e885b6425", "_content_type_id":
+        "ostree"}, "_id": {"$oid": "58d35a4917f568015721d3d0"}, "unit_id": "16cc5bbf-699c-4c42-add5-422e885b6425",
+        "unit_type_id": "ostree"}, {"metadata": {"_id": "d3e3386e-5bac-4a96-864b-92d03253cfec",
+        "_content_type_id": "ostree"}, "_id": {"$oid": "58d35a4917f568015721d3d1"},
+        "unit_id": "d3e3386e-5bac-4a96-864b-92d03253cfec", "unit_type_id": "ostree"}]'
     http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:49 GMT
+  recorded_at: Thu, 23 Mar 2017 05:16:57 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/ostree_branch_repository_unit_list/ostree_branches.yml
+++ b/test/fixtures/vcr_cassettes/extensions/ostree_branch_repository_unit_list/ostree_branches.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Feb 2017 12:30:49 GMT
+      - Thu, 23 Mar 2017 05:16:57 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -36,22 +36,22 @@ http_interactions:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
-      string: '[{"metadata": {"_storage_path": "/var/lib/pulp/content/shared/ostree/26760a9b7480dbfac877f6c0401a19da5e4d3e2292a5864b8820694f41cb5de9/links/8f958529-8425-4a97-befd-3283e77665be",
-        "_ns": "units_ostree", "_last_updated": 1485952002, "remote_id": "b1046db191900ad624224c3826f095786a2a09b8c26968f30b81fd7e71aa632b",
-        "_content_type_id": "ostree", "pulp_user_metadata": {}, "branch": "fedora-atomic/f21/x86_64/updates/docker-host",
-        "_created": "2017-02-01T12:26:42Z", "commit": "b2179ef2c16343758ebebaa1dfdf40cca8a76d5418ad1780d19b708ff2202dcf",
-        "_id": "8f958529-8425-4a97-befd-3283e77665be", "metadata": {"version": "23.3"}},
-        "updated": "2017-02-01T12:30:49Z", "repo_id": "integration_test_id", "created":
-        "2017-02-01T12:30:49Z", "unit_type_id": "ostree", "unit_id": "8f958529-8425-4a97-befd-3283e77665be",
-        "_id": {"$oid": "5891d4f94b92d9e3004e81da"}}, {"metadata": {"_storage_path":
-        "/var/lib/pulp/content/shared/ostree/26760a9b7480dbfac877f6c0401a19da5e4d3e2292a5864b8820694f41cb5de9/links/f3f067ea-2fd6-40b3-b138-cc28117063ed",
-        "_ns": "units_ostree", "_last_updated": 1485952002, "remote_id": "b1046db191900ad624224c3826f095786a2a09b8c26968f30b81fd7e71aa632b",
+      string: '[{"metadata": {"_storage_path": "/var/lib/pulp/content/shared/ostree/26760a9b7480dbfac877f6c0401a19da5e4d3e2292a5864b8820694f41cb5de9/links/16cc5bbf-699c-4c42-add5-422e885b6425",
+        "_ns": "units_ostree", "_last_updated": 1490246217, "remote_id": "b1046db191900ad624224c3826f095786a2a09b8c26968f30b81fd7e71aa632b",
         "_content_type_id": "ostree", "pulp_user_metadata": {}, "branch": "fedora-atomic/f21/x86_64/updates-testing/docker-host",
-        "_created": "2017-02-01T12:26:42Z", "commit": "b954defc0c21b23705bf5776a78ca434b2569260e64e19fb61bdbd5526b3bf0f",
-        "_id": "f3f067ea-2fd6-40b3-b138-cc28117063ed", "metadata": {"version": "23.3"}},
-        "updated": "2017-02-01T12:30:49Z", "repo_id": "integration_test_id", "created":
-        "2017-02-01T12:30:49Z", "unit_type_id": "ostree", "unit_id": "f3f067ea-2fd6-40b3-b138-cc28117063ed",
-        "_id": {"$oid": "5891d4f94b92d9e3004e81d9"}}]'
+        "_created": "2017-03-23T05:16:57Z", "commit": "b954defc0c21b23705bf5776a78ca434b2569260e64e19fb61bdbd5526b3bf0f",
+        "_id": "16cc5bbf-699c-4c42-add5-422e885b6425", "metadata": {"version": "23.3"}},
+        "updated": "2017-03-23T05:16:57Z", "repo_id": "integration_test_id", "created":
+        "2017-03-23T05:16:57Z", "unit_type_id": "ostree", "unit_id": "16cc5bbf-699c-4c42-add5-422e885b6425",
+        "_id": {"$oid": "58d35a4917f568015721d3d0"}}, {"metadata": {"_storage_path":
+        "/var/lib/pulp/content/shared/ostree/26760a9b7480dbfac877f6c0401a19da5e4d3e2292a5864b8820694f41cb5de9/links/d3e3386e-5bac-4a96-864b-92d03253cfec",
+        "_ns": "units_ostree", "_last_updated": 1490246217, "remote_id": "b1046db191900ad624224c3826f095786a2a09b8c26968f30b81fd7e71aa632b",
+        "_content_type_id": "ostree", "pulp_user_metadata": {}, "branch": "fedora-atomic/f21/x86_64/updates/docker-host",
+        "_created": "2017-03-23T05:16:57Z", "commit": "b2179ef2c16343758ebebaa1dfdf40cca8a76d5418ad1780d19b708ff2202dcf",
+        "_id": "d3e3386e-5bac-4a96-864b-92d03253cfec", "metadata": {"version": "23.3"}},
+        "updated": "2017-03-23T05:16:57Z", "repo_id": "integration_test_id", "created":
+        "2017-03-23T05:16:57Z", "unit_type_id": "ostree", "unit_id": "d3e3386e-5bac-4a96-864b-92d03253cfec",
+        "_id": {"$oid": "58d35a4917f568015721d3d1"}}]'
     http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:49 GMT
+  recorded_at: Thu, 23 Mar 2017 05:16:57 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/ostree_branch_repository_unit_list/suite.yml
+++ b/test/fixtures/vcr_cassettes/extensions/ostree_branch_repository_unit_list/suite.yml
@@ -567,165 +567,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:28:57 GMT
 - request:
-    method: delete
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: NOT FOUND
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '454'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"http_request_method": "DELETE", "exception": null, "error_message":
-        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/",
-        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
-        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
-        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:49 GMT
-- request:
-    method: get
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: NOT FOUND
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '452'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"http_request_method": "GET", "exception": null, "error_message":
-        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
-        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
-        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
-        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:49 GMT
-- request:
-    method: post
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      string: '{"id":"integration_test_id","importer_type_id":"ostree_web_importer","importer_config":{"feed":"file:///var/www/repositories/ostree/fedora"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '141'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '319'
-      Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
-        {}, "_ns": "repos", "_id": {"$oid": "5891d4f970be6f18c88f24bc"}, "id": "integration_test_id",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:49 GMT
-- request:
-    method: post
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/actions/sync/
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '2'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/f35dc211-6431-491d-b0f4-b2ae59b0711e/",
-        "task_id": "f35dc211-6431-491d-b0f4-b2ae59b0711e"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:49 GMT
-- request:
     method: get
     uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/f35dc211-6431-491d-b0f4-b2ae59b0711e/
     body:
@@ -809,43 +650,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:30:49 GMT
 - request:
-    method: delete
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/882cf2a6-101c-4fec-9505-99357aaca4f4/",
-        "task_id": "882cf2a6-101c-4fec-9505-99357aaca4f4"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:50 GMT
-- request:
     method: get
     uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/882cf2a6-101c-4fec-9505-99357aaca4f4/
     body:
@@ -890,4 +694,328 @@ http_interactions:
         "id": "5891d4fa4b92d9e3004e81db"}'
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:30:50 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '454'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"http_request_method": "DELETE", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:56 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '452'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"http_request_method": "GET", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/?",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:56 GMT
+- request:
+    method: post
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"ostree_web_importer","importer_config":{"feed":"file:///var/www/repositories/ostree/fedora"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '141'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "58d35a4870be6f5a6bf5ac22"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:56 GMT
+- request:
+    method: post
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/actions/sync/
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/45662e59-e291-449f-a32a-8e5e187a00d4/",
+        "task_id": "45662e59-e291-449f-a32a-8e5e187a00d4"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:56 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/45662e59-e291-449f-a32a-8e5e187a00d4/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3788'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.managers.repo.sync.sync",
+        "_href": "/pulp/api/v2/tasks/45662e59-e291-449f-a32a-8e5e187a00d4/", "task_id":
+        "45662e59-e291-449f-a32a-8e5e187a00d4", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:sync"], "finish_time": "2017-03-23T05:16:57Z", "_ns": "task_status",
+        "start_time": "2017-03-23T05:16:56Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {"ostree_web_importer": [{"num_success": 1, "description":
+        "Create Local Repository", "step_type": "import_create_repository", "items_total":
+        1, "state": "FINISHED", "error_details": [], "details": "", "num_failures":
+        0, "step_id": "4c24b836-918c-4803-817a-94c8e6594102", "num_processed": 1},
+        {"num_success": 1, "description": "Update Summary", "step_type": "import_summary",
+        "items_total": 1, "state": "FINISHED", "error_details": [], "details": "",
+        "num_failures": 0, "step_id": "a6dc0425-14d0-4ac0-a216-8582037e433c", "num_processed":
+        1}, {"num_success": 1, "description": "Pull Remote Branches", "step_type":
+        "import_pull", "items_total": 1, "state": "FINISHED", "error_details": [],
+        "details": "", "num_failures": 0, "step_id": "09c360d7-1766-410c-8c06-805049f153f3",
+        "num_processed": 1}, {"num_success": 1, "description": "Add Content Units",
+        "step_type": "import_add_unit", "items_total": 1, "state": "FINISHED", "error_details":
+        [], "details": "", "num_failures": 0, "step_id": "c5e776f8-f129-4e19-945c-d8d575546bd6",
+        "num_processed": 1}, {"num_success": 1, "description": "Clean", "step_type":
+        "import_clean", "items_total": 1, "state": "FINISHED", "error_details": [],
+        "details": "", "num_failures": 0, "step_id": "d443f22c-9905-46b3-b3d8-0bceda35bc2c",
+        "num_processed": 1}]}, "queue": "reserved_resource_worker-1@obelix.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-1@obelix.example.com",
+        "result": {"result": "success", "importer_id": "ostree_web_importer", "exception":
+        null, "repo_id": "integration_test_id", "traceback": null, "started": "2017-03-23T05:16:56Z",
+        "_ns": "repo_sync_results", "completed": "2017-03-23T05:16:57Z", "importer_type_id":
+        "ostree_web_importer", "error_message": null, "summary": {"import_summary":
+        "FINISHED", "import_create_repository": "FINISHED", "import_pull": "FINISHED",
+        "import_clean": "FINISHED", "import_add_unit": "FINISHED"}, "added_count":
+        2, "removed_count": 0, "updated_count": 0, "id": "58d35a4970be6f07e1339c71",
+        "details": [{"num_success": 1, "description": "Create Local Repository", "step_type":
+        "import_create_repository", "items_total": 1, "state": "FINISHED", "error_details":
+        [], "details": "", "num_failures": 0, "step_id": "4c24b836-918c-4803-817a-94c8e6594102",
+        "num_processed": 1}, {"num_success": 1, "description": "Update Summary", "step_type":
+        "import_summary", "items_total": 1, "state": "FINISHED", "error_details":
+        [], "details": "", "num_failures": 0, "step_id": "a6dc0425-14d0-4ac0-a216-8582037e433c",
+        "num_processed": 1}, {"num_success": 1, "description": "Pull Remote Branches",
+        "step_type": "import_pull", "items_total": 1, "state": "FINISHED", "error_details":
+        [], "details": "", "num_failures": 0, "step_id": "09c360d7-1766-410c-8c06-805049f153f3",
+        "num_processed": 1}, {"num_success": 1, "description": "Add Content Units",
+        "step_type": "import_add_unit", "items_total": 1, "state": "FINISHED", "error_details":
+        [], "details": "", "num_failures": 0, "step_id": "c5e776f8-f129-4e19-945c-d8d575546bd6",
+        "num_processed": 1}, {"num_success": 1, "description": "Clean", "step_type":
+        "import_clean", "items_total": 1, "state": "FINISHED", "error_details": [],
+        "details": "", "num_failures": 0, "step_id": "d443f22c-9905-46b3-b3d8-0bceda35bc2c",
+        "num_processed": 1}]}, "error": null, "_id": {"$oid": "58d35a4817f568015721d3cf"},
+        "id": "58d35a4817f568015721d3cf"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:57 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/b54848b2-1ec4-4736-a167-45936517cac3/",
+        "task_id": "b54848b2-1ec4-4736-a167-45936517cac3"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:57 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/b54848b2-1ec4-4736-a167-45936517cac3/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/b54848b2-1ec4-4736-a167-45936517cac3/", "task_id":
+        "b54848b2-1ec4-4736-a167-45936517cac3", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-03-23T05:16:57Z", "_ns": "task_status",
+        "start_time": "2017-03-23T05:16:57Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-1@obelix.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-1@obelix.example.com",
+        "result": null, "error": null, "_id": {"$oid": "58d35a4917f568015721d3d2"},
+        "id": "58d35a4917f568015721d3d2"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:58 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_distributor_object.yml
+++ b/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_distributor_object.yml
@@ -179,132 +179,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:29:00 GMT
 - request:
-    method: post
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      string: '{"id":"integration_test_id_distro","distributors":[{"distributor_type_id":"ostree_web_distributor","distributor_config":{"ostree_publish_directory":"/path","relative_path":"/relative_path"},"auto_publish":false,"distributor_id":"123"}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '236'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '340'
-      Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id_distro/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"scratchpad": {}, "display_name": "integration_test_id_distro", "description":
-        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
-        {}, "_ns": "repos", "_id": {"$oid": "5891d4fc70be6f18c88f24be"}, "id": "integration_test_id_distro",
-        "_href": "/pulp/api/v2/repositories/integration_test_id_distro/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:52 GMT
-- request:
-    method: get
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id_distro/?details=true
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '907'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      string: '{"scratchpad": {}, "display_name": "integration_test_id_distro", "description":
-        null, "distributors": [{"repo_id": "integration_test_id_distro", "last_updated":
-        "2017-02-01T12:30:52Z", "_href": "/pulp/api/v2/repositories/integration_test_id_distro/distributors/123/",
-        "last_override_config": {}, "last_publish": null, "distributor_type_id": "ostree_web_distributor",
-        "auto_publish": false, "scratchpad": {}, "_ns": "repo_distributors", "_id":
-        {"$oid": "5891d4fc70be6f18c88f24bf"}, "config": {"ostree_publish_directory":
-        "/path", "relative_path": "/relative_path"}, "id": "123"}], "last_unit_added":
-        null, "notes": {}, "last_unit_removed": null, "content_unit_counts": {}, "_ns":
-        "repos", "importers": [], "locally_stored_units": 0, "_id": {"$oid": "5891d4fc70be6f18c88f24be"},
-        "total_repository_units": 0, "id": "integration_test_id_distro", "_href":
-        "/pulp/api/v2/repositories/integration_test_id_distro/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:52 GMT
-- request:
-    method: delete
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id_distro/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/2b1c7820-9365-4fec-b2cd-0ff5295bb1c0/",
-        "task_id": "2b1c7820-9365-4fec-b2cd-0ff5295bb1c0"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:52 GMT
-- request:
     method: get
     uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/2b1c7820-9365-4fec-b2cd-0ff5295bb1c0/
     body:
@@ -350,6 +224,177 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:30:52 GMT
 - request:
+    method: post
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id_distro","distributors":[{"distributor_type_id":"ostree_web_distributor","distributor_config":{"ostree_publish_directory":"/path","relative_path":"/relative_path"},"auto_publish":false,"distributor_id":"123"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '236'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '340'
+      Location:
+      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id_distro/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id_distro", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "58d35a4a70be6f5a695eb23e"}, "id": "integration_test_id_distro",
+        "_href": "/pulp/api/v2/repositories/integration_test_id_distro/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:58 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id_distro/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '907'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id_distro", "description":
+        null, "distributors": [{"repo_id": "integration_test_id_distro", "last_updated":
+        "2017-03-23T05:16:58Z", "_href": "/pulp/api/v2/repositories/integration_test_id_distro/distributors/123/",
+        "last_override_config": {}, "last_publish": null, "distributor_type_id": "ostree_web_distributor",
+        "auto_publish": false, "scratchpad": {}, "_ns": "repo_distributors", "_id":
+        {"$oid": "58d35a4a70be6f5a695eb23f"}, "config": {"ostree_publish_directory":
+        "/path", "relative_path": "/relative_path"}, "id": "123"}], "last_unit_added":
+        null, "notes": {}, "last_unit_removed": null, "content_unit_counts": {}, "_ns":
+        "repos", "importers": [], "locally_stored_units": 0, "_id": {"$oid": "58d35a4a70be6f5a695eb23e"},
+        "total_repository_units": 0, "id": "integration_test_id_distro", "_href":
+        "/pulp/api/v2/repositories/integration_test_id_distro/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:58 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id_distro/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/c961f136-91d5-42e9-8fb2-6ac9dc173514/",
+        "task_id": "c961f136-91d5-42e9-8fb2-6ac9dc173514"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:58 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/c961f136-91d5-42e9-8fb2-6ac9dc173514/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '687'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/c961f136-91d5-42e9-8fb2-6ac9dc173514/", "task_id":
+        "c961f136-91d5-42e9-8fb2-6ac9dc173514", "tags": ["pulp:repository:integration_test_id_distro",
+        "pulp:action:delete"], "finish_time": "2017-03-23T05:16:58Z", "_ns": "task_status",
+        "start_time": "2017-03-23T05:16:58Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-1@obelix.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-1@obelix.example.com",
+        "result": null, "error": null, "_id": {"$oid": "58d35a4a17f568015721d3d3"},
+        "id": "58d35a4a17f568015721d3d3"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:59 GMT
+- request:
     method: delete
     uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
     body:
@@ -370,7 +415,7 @@ http_interactions:
       message: NOT FOUND
     headers:
       Date:
-      - Wed, 01 Feb 2017 12:30:52 GMT
+      - Thu, 23 Mar 2017 05:16:59 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -387,5 +432,5 @@ http_interactions:
         "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
         "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
     http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:52 GMT
+  recorded_at: Thu, 23 Mar 2017 05:16:59 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_distributors.yml
+++ b/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_distributors.yml
@@ -179,85 +179,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:28:58 GMT
 - request:
-    method: post
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      string: '{"id":"integration_test_id","distributors":[{"distributor_type_id":"ostree_web_distributor","distributor_config":{"ostree_publish_directory":"/path"},"auto_publish":true,"distributor_id":"123"}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '195'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '319'
-      Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
-        {}, "_ns": "repos", "_id": {"$oid": "5891d4fb70be6f18c78ca851"}, "id": "integration_test_id",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:51 GMT
-- request:
-    method: delete
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/96211d69-88bb-4475-a460-41b482ed1fcb/",
-        "task_id": "96211d69-88bb-4475-a460-41b482ed1fcb"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:51 GMT
-- request:
     method: get
     uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/96211d69-88bb-4475-a460-41b482ed1fcb/
     body:
@@ -302,4 +223,128 @@ http_interactions:
         "id": "5891d4fb4b92d9e3004e81dd"}'
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:30:52 GMT
+- request:
+    method: post
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","distributors":[{"distributor_type_id":"ostree_web_distributor","distributor_config":{"ostree_publish_directory":"/path"},"auto_publish":true,"distributor_id":"123"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '195'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "58d35a4d70be6f5a6a792828"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:01 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/4020a48f-b676-4bc8-8dbd-805aa45857d5/",
+        "task_id": "4020a48f-b676-4bc8-8dbd-805aa45857d5"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:01 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/4020a48f-b676-4bc8-8dbd-805aa45857d5/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/4020a48f-b676-4bc8-8dbd-805aa45857d5/", "task_id":
+        "4020a48f-b676-4bc8-8dbd-805aa45857d5", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-03-23T05:17:01Z", "_ns": "task_status",
+        "start_time": "2017-03-23T05:17:01Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-1@obelix.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-1@obelix.example.com",
+        "result": null, "error": null, "_id": {"$oid": "58d35a4d17f568015721d3d7"},
+        "id": "58d35a4d17f568015721d3d7"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:02 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_importer.yml
+++ b/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_importer.yml
@@ -179,130 +179,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:30:37 GMT
 - request:
-    method: post
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      string: '{"id":"integration_test_id","importer_type_id":"ostree_web_importer","importer_config":{}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '90'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '319'
-      Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
-        {}, "_ns": "repos", "_id": {"$oid": "5891d4fd70be6f18c88f24c2"}, "id": "integration_test_id",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:53 GMT
-- request:
-    method: get
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/?details=true
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '798'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "distributors": [], "last_unit_added": null, "notes": {}, "last_unit_removed":
-        null, "content_unit_counts": {}, "_ns": "repos", "importers": [{"repo_id":
-        "integration_test_id", "last_updated": "2017-02-01T12:30:53Z", "_href": "/pulp/api/v2/repositories/integration_test_id/importers/ostree_web_importer/",
-        "_ns": "repo_importers", "importer_type_id": "ostree_web_importer", "last_override_config":
-        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "5891d4fd70be6f18c88f24c3"},
-        "config": {}, "id": "ostree_web_importer"}], "locally_stored_units": 0, "_id":
-        {"$oid": "5891d4fd70be6f18c88f24c2"}, "total_repository_units": 0, "id": "integration_test_id",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:53 GMT
-- request:
-    method: delete
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/a055e68c-9c8b-4826-9583-7ce1f3834b71/",
-        "task_id": "a055e68c-9c8b-4826-9583-7ce1f3834b71"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:53 GMT
-- request:
     method: get
     uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/a055e68c-9c8b-4826-9583-7ce1f3834b71/
     body:
@@ -347,4 +223,173 @@ http_interactions:
         "id": "5891d4fd4b92d9e3004e81e0"}'
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:30:54 GMT
+- request:
+    method: post
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"ostree_web_importer","importer_config":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '90'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "58d35a4c70be6f5a6bf5ac24"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:00 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '798'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "distributors": [], "last_unit_added": null, "notes": {}, "last_unit_removed":
+        null, "content_unit_counts": {}, "_ns": "repos", "importers": [{"repo_id":
+        "integration_test_id", "last_updated": "2017-03-23T05:17:00Z", "_href": "/pulp/api/v2/repositories/integration_test_id/importers/ostree_web_importer/",
+        "_ns": "repo_importers", "importer_type_id": "ostree_web_importer", "last_override_config":
+        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "58d35a4c70be6f5a6bf5ac25"},
+        "config": {}, "id": "ostree_web_importer"}], "locally_stored_units": 0, "_id":
+        {"$oid": "58d35a4c70be6f5a6bf5ac24"}, "total_repository_units": 0, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:00 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/32bc5ef6-ec9d-49e1-8244-bba9c0c55e98/",
+        "task_id": "32bc5ef6-ec9d-49e1-8244-bba9c0c55e98"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:00 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/32bc5ef6-ec9d-49e1-8244-bba9c0c55e98/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/32bc5ef6-ec9d-49e1-8244-bba9c0c55e98/", "task_id":
+        "32bc5ef6-ec9d-49e1-8244-bba9c0c55e98", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-03-23T05:17:00Z", "_ns": "task_status",
+        "start_time": "2017-03-23T05:17:00Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-1@obelix.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-1@obelix.example.com",
+        "result": null, "error": null, "_id": {"$oid": "58d35a4c17f568015721d3d5"},
+        "id": "58d35a4c17f568015721d3d5"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:00 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_importer_and_distributors.yml
+++ b/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_importer_and_distributors.yml
@@ -179,135 +179,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:28:58 GMT
 - request:
-    method: post
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      string: '{"id":"integration_test_id","importer_type_id":"ostree_web_importer","importer_config":{},"distributors":[{"distributor_type_id":"ostree_web_distributor","distributor_config":{},"auto_publish":true,"distributor_id":"123"}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '223'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '319'
-      Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
-        {}, "_ns": "repos", "_id": {"$oid": "5891d4fa70be6f18c78ca84e"}, "id": "integration_test_id",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:50 GMT
-- request:
-    method: get
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/?details=true
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1187'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "distributors": [{"repo_id": "integration_test_id", "last_updated":
-        "2017-02-01T12:30:50Z", "_href": "/pulp/api/v2/repositories/integration_test_id/distributors/123/",
-        "last_override_config": {}, "last_publish": null, "distributor_type_id": "ostree_web_distributor",
-        "auto_publish": true, "scratchpad": {}, "_ns": "repo_distributors", "_id":
-        {"$oid": "5891d4fa70be6f18c78ca850"}, "config": {}, "id": "123"}], "last_unit_added":
-        null, "notes": {}, "last_unit_removed": null, "content_unit_counts": {}, "_ns":
-        "repos", "importers": [{"repo_id": "integration_test_id", "last_updated":
-        "2017-02-01T12:30:50Z", "_href": "/pulp/api/v2/repositories/integration_test_id/importers/ostree_web_importer/",
-        "_ns": "repo_importers", "importer_type_id": "ostree_web_importer", "last_override_config":
-        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "5891d4fa70be6f18c78ca84f"},
-        "config": {}, "id": "ostree_web_importer"}], "locally_stored_units": 0, "_id":
-        {"$oid": "5891d4fa70be6f18c78ca84e"}, "total_repository_units": 0, "id": "integration_test_id",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:50 GMT
-- request:
-    method: delete
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/e9624ca4-f968-4ae9-9dfb-604c15164f0f/",
-        "task_id": "e9624ca4-f968-4ae9-9dfb-604c15164f0f"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:50 GMT
-- request:
     method: get
     uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/e9624ca4-f968-4ae9-9dfb-604c15164f0f/
     body:
@@ -352,4 +223,178 @@ http_interactions:
         "id": "5891d4fa4b92d9e3004e81dc"}'
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:30:51 GMT
+- request:
+    method: post
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"ostree_web_importer","importer_config":{},"distributors":[{"distributor_type_id":"ostree_web_distributor","distributor_config":{},"auto_publish":true,"distributor_id":"123"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '223'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "58d35a4c70be6f5a695eb240"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:00 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1187'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "distributors": [{"repo_id": "integration_test_id", "last_updated":
+        "2017-03-23T05:17:00Z", "_href": "/pulp/api/v2/repositories/integration_test_id/distributors/123/",
+        "last_override_config": {}, "last_publish": null, "distributor_type_id": "ostree_web_distributor",
+        "auto_publish": true, "scratchpad": {}, "_ns": "repo_distributors", "_id":
+        {"$oid": "58d35a4c70be6f5a695eb242"}, "config": {}, "id": "123"}], "last_unit_added":
+        null, "notes": {}, "last_unit_removed": null, "content_unit_counts": {}, "_ns":
+        "repos", "importers": [{"repo_id": "integration_test_id", "last_updated":
+        "2017-03-23T05:17:00Z", "_href": "/pulp/api/v2/repositories/integration_test_id/importers/ostree_web_importer/",
+        "_ns": "repo_importers", "importer_type_id": "ostree_web_importer", "last_override_config":
+        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "58d35a4c70be6f5a695eb241"},
+        "config": {}, "id": "ostree_web_importer"}], "locally_stored_units": 0, "_id":
+        {"$oid": "58d35a4c70be6f5a695eb240"}, "total_repository_units": 0, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:00 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/a03995bc-582f-4e87-8d91-1771383e1042/",
+        "task_id": "a03995bc-582f-4e87-8d91-1771383e1042"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:01 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/a03995bc-582f-4e87-8d91-1771383e1042/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/a03995bc-582f-4e87-8d91-1771383e1042/", "task_id":
+        "a03995bc-582f-4e87-8d91-1771383e1042", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-03-23T05:17:01Z", "_ns": "task_status",
+        "start_time": "2017-03-23T05:17:01Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-1@obelix.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-1@obelix.example.com",
+        "result": null, "error": null, "_id": {"$oid": "58d35a4c17f568015721d3d6"},
+        "id": "58d35a4c17f568015721d3d6"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:01 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_importer_and_distributors_objects.yml
+++ b/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_importer_and_distributors_objects.yml
@@ -262,93 +262,6 @@ http_interactions:
   recorded_at: Wed, 01 Feb 2017 12:30:54 GMT
 - request:
     method: get
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/?details=true
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1221'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "distributors": [{"repo_id": "integration_test_id", "last_updated":
-        "2017-02-01T12:30:54Z", "_href": "/pulp/api/v2/repositories/integration_test_id/distributors/123/",
-        "last_override_config": {}, "last_publish": null, "distributor_type_id": "ostree_web_distributor",
-        "auto_publish": false, "scratchpad": {}, "_ns": "repo_distributors", "_id":
-        {"$oid": "5891d4fe70be6f18c91f61d9"}, "config": {}, "id": "123"}], "last_unit_added":
-        null, "notes": {"_repo-type": "OSTREE"}, "last_unit_removed": null, "content_unit_counts":
-        {}, "_ns": "repos", "importers": [{"repo_id": "integration_test_id", "last_updated":
-        "2017-02-01T12:30:54Z", "_href": "/pulp/api/v2/repositories/integration_test_id/importers/ostree_web_importer/",
-        "_ns": "repo_importers", "importer_type_id": "ostree_web_importer", "last_override_config":
-        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "5891d4fe70be6f18c91f61d8"},
-        "config": {"depth": -1}, "id": "ostree_web_importer"}], "locally_stored_units":
-        0, "_id": {"$oid": "5891d4fe70be6f18c91f61d7"}, "total_repository_units":
-        0, "id": "integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:54 GMT
-- request:
-    method: delete
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/34b2728e-41c7-4c47-9ca4-b494b3b5916e/",
-        "task_id": "34b2728e-41c7-4c47-9ca4-b494b3b5916e"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:54 GMT
-- request:
-    method: get
     uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/34b2728e-41c7-4c47-9ca4-b494b3b5916e/
     body:
       encoding: US-ASCII
@@ -392,4 +305,178 @@ http_interactions:
         "id": "5891d4fe4b92d9e3004e81e1"}'
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:30:55 GMT
+- request:
+    method: post
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"ostree_web_importer","importer_config":{"depth":4},"notes":{"_repo-type":"OSTREE"},"distributors":[{"distributor_type_id":"ostree_web_distributor","distributor_config":{"depth":-1},"auto_publish":false,"distributor_id":"123"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '275'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '341'
+      Location:
+      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {"_repo-type": "OSTREE"}, "last_unit_removed":
+        null, "content_unit_counts": {}, "_ns": "repos", "_id": {"$oid": "58d35a4b70be6f5a6a792825"},
+        "id": "integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:59 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1231'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "distributors": [{"repo_id": "integration_test_id", "last_updated":
+        "2017-03-23T05:16:59Z", "_href": "/pulp/api/v2/repositories/integration_test_id/distributors/123/",
+        "last_override_config": {}, "last_publish": null, "distributor_type_id": "ostree_web_distributor",
+        "auto_publish": false, "scratchpad": {}, "_ns": "repo_distributors", "_id":
+        {"$oid": "58d35a4b70be6f5a6a792827"}, "config": {"depth": -1}, "id": "123"}],
+        "last_unit_added": null, "notes": {"_repo-type": "OSTREE"}, "last_unit_removed":
+        null, "content_unit_counts": {}, "_ns": "repos", "importers": [{"repo_id":
+        "integration_test_id", "last_updated": "2017-03-23T05:16:59Z", "_href": "/pulp/api/v2/repositories/integration_test_id/importers/ostree_web_importer/",
+        "_ns": "repo_importers", "importer_type_id": "ostree_web_importer", "last_override_config":
+        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "58d35a4b70be6f5a6a792826"},
+        "config": {"depth": 4}, "id": "ostree_web_importer"}], "locally_stored_units":
+        0, "_id": {"$oid": "58d35a4b70be6f5a6a792825"}, "total_repository_units":
+        0, "id": "integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:59 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/412e94cd-8195-4055-a2de-74b245cf068a/",
+        "task_id": "412e94cd-8195-4055-a2de-74b245cf068a"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:59 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/412e94cd-8195-4055-a2de-74b245cf068a/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:16:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/412e94cd-8195-4055-a2de-74b245cf068a/", "task_id":
+        "412e94cd-8195-4055-a2de-74b245cf068a", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-03-23T05:16:59Z", "_ns": "task_status",
+        "start_time": "2017-03-23T05:16:59Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-1@obelix.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-1@obelix.example.com",
+        "result": null, "error": null, "_id": {"$oid": "58d35a4b17f568015721d3d4"},
+        "id": "58d35a4b17f568015721d3d4"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:16:59 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_importer_object.yml
+++ b/test/fixtures/vcr_cassettes/extensions/ostree_repository_create/create_with_importer_object.yml
@@ -179,133 +179,6 @@ http_interactions:
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:28:59 GMT
 - request:
-    method: post
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      string: '{"id":"integration_test_id","importer_type_id":"ostree_web_importer","importer_config":{"feed":"http://cdn.qa.redhat.com/content/htb/rhel/server/7/x86_64/extras/ostree/","branches":["redhat-atomic-host/el7.0/x86_64/base","redhat-atomic-host/el7.0/x86_64/medium"]},"notes":{"_repo-type":"OSTREE"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '296'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '341'
-      Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "last_unit_added": null, "notes": {"_repo-type": "OSTREE"}, "last_unit_removed":
-        null, "content_unit_counts": {}, "_ns": "repos", "_id": {"$oid": "5891d4fc70be6f18c88f24c0"},
-        "id": "integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:52 GMT
-- request:
-    method: get
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/?details=true
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '998'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
-        null, "distributors": [], "last_unit_added": null, "notes": {"_repo-type":
-        "OSTREE"}, "last_unit_removed": null, "content_unit_counts": {}, "_ns": "repos",
-        "importers": [{"repo_id": "integration_test_id", "last_updated": "2017-02-01T12:30:52Z",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/importers/ostree_web_importer/",
-        "_ns": "repo_importers", "importer_type_id": "ostree_web_importer", "last_override_config":
-        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "5891d4fc70be6f18c88f24c1"},
-        "config": {"feed": "http://cdn.qa.redhat.com/content/htb/rhel/server/7/x86_64/extras/ostree/",
-        "branches": ["redhat-atomic-host/el7.0/x86_64/base", "redhat-atomic-host/el7.0/x86_64/medium"]},
-        "id": "ostree_web_importer"}], "locally_stored_units": 0, "_id": {"$oid":
-        "5891d4fc70be6f18c88f24c0"}, "total_repository_units": 0, "id": "integration_test_id",
-        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:52 GMT
-- request:
-    method: delete
-    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Wed, 01 Feb 2017 12:30:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/c1f81209-23f8-4998-91ab-c1a9e042e1cc/",
-        "task_id": "c1f81209-23f8-4998-91ab-c1a9e042e1cc"}], "result": null, "error":
-        null}'
-    http_version: 
-  recorded_at: Wed, 01 Feb 2017 12:30:53 GMT
-- request:
     method: get
     uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/c1f81209-23f8-4998-91ab-c1a9e042e1cc/
     body:
@@ -350,4 +223,176 @@ http_interactions:
         "id": "5891d4fd4b92d9e3004e81df"}'
     http_version: 
   recorded_at: Wed, 01 Feb 2017 12:30:53 GMT
+- request:
+    method: post
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"ostree_web_importer","importer_config":{"feed":"http://cdn.qa.redhat.com/content/htb/rhel/server/7/x86_64/extras/ostree/","branches":["redhat-atomic-host/el7.0/x86_64/base","redhat-atomic-host/el7.0/x86_64/medium"]},"notes":{"_repo-type":"OSTREE"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '296'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '341'
+      Location:
+      - https://obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {"_repo-type": "OSTREE"}, "last_unit_removed":
+        null, "content_unit_counts": {}, "_ns": "repos", "_id": {"$oid": "58d35a4e70be6f5a6bf5ac26"},
+        "id": "integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:02 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '998'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "distributors": [], "last_unit_added": null, "notes": {"_repo-type":
+        "OSTREE"}, "last_unit_removed": null, "content_unit_counts": {}, "_ns": "repos",
+        "importers": [{"repo_id": "integration_test_id", "last_updated": "2017-03-23T05:17:02Z",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/importers/ostree_web_importer/",
+        "_ns": "repo_importers", "importer_type_id": "ostree_web_importer", "last_override_config":
+        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "58d35a4e70be6f5a6bf5ac27"},
+        "config": {"feed": "http://cdn.qa.redhat.com/content/htb/rhel/server/7/x86_64/extras/ostree/",
+        "branches": ["redhat-atomic-host/el7.0/x86_64/base", "redhat-atomic-host/el7.0/x86_64/medium"]},
+        "id": "ostree_web_importer"}], "locally_stored_units": 0, "_id": {"$oid":
+        "58d35a4e70be6f5a6bf5ac26"}, "total_repository_units": 0, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:02 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/7a6c745d-564d-4580-bb75-b196ad25da6e/",
+        "task_id": "7a6c745d-564d-4580-bb75-b196ad25da6e"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:02 GMT
+- request:
+    method: get
+    uri: https://admin:admin@obelix.example.com/pulp/api/v2/tasks/7a6c745d-564d-4580-bb75-b196ad25da6e/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Mar 2017 05:17:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/7a6c745d-564d-4580-bb75-b196ad25da6e/", "task_id":
+        "7a6c745d-564d-4580-bb75-b196ad25da6e", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-03-23T05:17:02Z", "_ns": "task_status",
+        "start_time": "2017-03-23T05:17:02Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-1@obelix.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-1@obelix.example.com",
+        "result": null, "error": null, "_id": {"$oid": "58d35a4e17f568015721d3d8"},
+        "id": "58d35a4e17f568015721d3d8"}'
+    http_version: 
+  recorded_at: Thu, 23 Mar 2017 05:17:03 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Prior to this commit one could only set depth for ostree importer.
This one enables one to set it for the distributor also.
This will enable pulp to selectively publish  what its synced from
upstream feed.