### PR TITLE
Fixes #19055 - add new call for generate applicability

### DIFF
--- a/lib/runcible/resources/consumer.rb
+++ b/lib/runcible/resources/consumer.rb
@@ -146,6 +146,16 @@ module Runcible
         call(:post, path('actions/content/regenerate_applicability/'), :payload => { :required => options})
       end
 
+      # (Re)Generate applicability for a single consumer. This does not cause a
+      # pulp lock, see https://pulp.plan.io/issues/1173#note-12
+      #
+      # @param  [String]               id      the ID of the consumer
+      # @param  [Hash]                 options payload representing criteria
+      # @return [RestClient::Response]
+      def regenerate_applicability_by_id(id, options = {})
+        call(:post, path(id) + 'actions/content/regenerate_applicability/', :payload => { :required => options})
+      end
+
       # retrieve the applicability for some set of consumers
       #
       # @param  [Hash]                  options hash representing criteria

--- a/test/fixtures/vcr_cassettes/resources/consumer_applicability/generate_applicability_one_id.yml
+++ b/test/fixtures/vcr_cassettes/resources/consumer_applicability/generate_applicability_one_id.yml
@@ -1,0 +1,159 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:oAoExV2f7EKidTk982PyfAnMCSioNdem@runcible.example.com/pulp/api/v2/consumers/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_consumer","name":"boo"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '47'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Tue, 28 Mar 2017 22:34:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2481'
+      Location:
+      - https://runcible.example.com/pulp/api/v2/consumers/integration_test_consumer/
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"consumer": {"display_name": "integration_test_consumer", "description":
+        null, "_ns": "consumers", "notes": {}, "rsa_pub": null, "capabilities": {},
+        "_id": {"$oid": "58dae4f3aca488018bf9e5f7"}, "id": "integration_test_consumer",
+        "_href": "/pulp/api/v2/consumers/integration_test_consumer/"}, "certificate":
+        "-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQC7fCk+0WEPBeJKHzmyhbVgMi2NlYd/GGDy27N3IA1iI6O6S0ea\n9RKEb+OCRcAT999eq69gKzG/HouqG0oWV2+IV8wLhzQqwSyRbA6IAq+GnTqnqiRt\nKHHTlmCB6p18rmFQw+OdFl1weU4lqerCpmKps4wZrRnPnJM1RyYxA5X0nwIDAQAB\nAoGALJ0IB421ZejFh1PU2/lbRq/KDTX2zzSS5VeIZiF3bdIDRPJi8Km+pUsmvTox\n0c6bFaEPE3hT1yHCpFDoGVbnEAdn/stCsOYeJJ1+7cyppzrZn0RLdxF8bt6WxRGF\nQN3jsiUGZ4qTruGIMPRV2iqQDh+sy51YNByIHAgdkBICk3ECQQDce/5UYpyJ5tEU\niLt010ZOi0ixZkBxupDzn5RW06KDK501FjVcMkNy9IFJcwIDtNiJ6nhhweuwSYEq\nh8T+5V95AkEA2a9jvKbW+P3GD3dMnkTsdw2ggPaWvgudIldIjB395yy0g7Z/CZ23\nQaAbHjfKFYB7hvzc3SpUbEJ4s0mAXTl21wJBAL0RmuOz+DaM9wfbxJwKKqEZ8Ykm\nfObJrJktY+Ac9YPz94hZdgKMm6hNITzh4X1aLEIADaEO0NRIA/p7mKNYAEkCQQCZ\nL+Ko9GOdbsB9S7/ANNKO6SkE+AKWlIesje3ApK5zizMw6TE27CT06p2Kw0nTncnP\n8Yvfm5UzZgeYa2YItJKbAkBVJVc3P+mTtNd8nI0k5+PHdgbz561/E2f7SUZGRWmw\n2I1VZI9K2FVb+qJFEr/XIRwXlusui8ARG/5cvpFUBoCc\n-----END
+        RSA PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDbTCCAVUCAgCkMA0GCSqGSIb3DQEBBQUAMC4xHTAbBgNVBAMMFHJ1bmNpYmxl\nLmV4YW1wbGUuY29tMQ0wCwYDVQQKDARQVUxQMB4XDTE3MDMyODIyMzQyN1oXDTI3\nMDMyNjIyMzQyN1owTjEiMCAGA1UEAxQZaW50ZWdyYXRpb25fdGVzdF9jb25zdW1l\ncjEoMCYGCgmSJomT8ixkAQETGDU4ZGFlNGYzYWNhNDg4MDE4YmY5ZTVmNzCBnzAN\nBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAu3wpPtFhDwXiSh85soW1YDItjZWHfxhg\n8tuzdyANYiOjuktHmvUShG/jgkXAE/ffXquvYCsxvx6LqhtKFldviFfMC4c0KsEs\nkWwOiAKvhp06p6okbShx05ZggeqdfK5hUMPjnRZdcHlOJanqwqZiqbOMGa0Zz5yT\nNUcmMQOV9J8CAwEAATANBgkqhkiG9w0BAQUFAAOCAgEALAfC6xo2C4yQ9DZgfr+i\nASdcErq/IFINbtLTb/JklGHPDokOtGeXu4NhYzjLomM2eJvjQlbcHVwQeDyb3APE\nfdjoazgEvjmD9/YtzoiPY6OC8apStZTviY40twWWrKcnLXMhD8y4QRNTnqzBlGHF\nCN4pdx2DMzMT4QYcyD+9sfx/F7ktlEAiitDGybOiT31RlRqG5qClLflmGq/hjh3v\nTk6RDgqchbNWXPGyzxyJIXjjOXYccETnovVQIbXYzYUmolOQ/dOA84E2CHHXvu9C\nMlmb3Acs4TkHSj1VS9OvK+cK8nB2MousafuO4lvPhfd12H3tsSBIgtACt+P8rhMJ\nJTmLQ4kD6kh78TrIywwxixIqQ4rApUxq8iGymk+BHOKDSZU2EjbdMtfcJh5xTwJB\n+Rt+NgZW7sFVnW78w4icuZfFshdDRkWnZ11wLGhBIHx+W9G/gneeHgMLNagRpT2T\n0qjAdbOrrCRlj53nIjLtn29xebU+5IhtWKIumqD6fUdz6wKtBnbcHtP+yeU4lb8G\nf4ehvukC+gUCy/PwFvIUy7o+mRLtg3LK8zUY6ipT8IApTs9IJRucNEW0Umw5aK7A\nNI/aiC2VkOqSDenFsqQd6nftLGysjxRRv4TxKcfhSYyXyJ1Fxt38FohpIPGfaYiE\nPIkfGKh14k3lYohcJQYe4bQ=\n-----END
+        CERTIFICATE-----"}'
+    http_version: 
+  recorded_at: Tue, 28 Mar 2017 22:34:27 GMT
+- request:
+    method: post
+    uri: https://admin:oAoExV2f7EKidTk982PyfAnMCSioNdem@runcible.example.com/pulp/api/v2/consumers/integration_test_consumer/actions/content/regenerate_applicability/
+    body:
+      encoding: UTF-8
+      string: '{}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Tue, 28 Mar 2017 22:34:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/0414f076-90bb-4b73-8dfc-cb3d1be12ede/",
+        "task_id": "0414f076-90bb-4b73-8dfc-cb3d1be12ede"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Tue, 28 Mar 2017 22:34:27 GMT
+- request:
+    method: get
+    uri: https://admin:oAoExV2f7EKidTk982PyfAnMCSioNdem@runcible.example.com/pulp/api/v2/tasks/0414f076-90bb-4b73-8dfc-cb3d1be12ede/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Mar 2017 22:34:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '729'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.managers.consumer.applicability.regenerate_applicability_for_consumers",
+        "_href": "/pulp/api/v2/tasks/0414f076-90bb-4b73-8dfc-cb3d1be12ede/", "task_id":
+        "0414f076-90bb-4b73-8dfc-cb3d1be12ede", "tags": ["pulp:action:consumer_content_applicability_regeneration"],
+        "finish_time": "2017-03-28T22:34:27Z", "_ns": "task_status", "start_time":
+        "2017-03-28T22:34:27Z", "traceback": null, "spawned_tasks": [], "progress_report":
+        {}, "queue": "reserved_resource_worker-0@runcible.example.com.dq", "state":
+        "finished", "worker_name": "reserved_resource_worker-0@runcible.example.com",
+        "result": null, "error": null, "_id": {"$oid": "58dae4f37b90bd635ef00a5f"},
+        "id": "58dae4f37b90bd635ef00a5f"}'
+    http_version: 
+  recorded_at: Tue, 28 Mar 2017 22:34:28 GMT
+- request:
+    method: delete
+    uri: https://admin:oAoExV2f7EKidTk982PyfAnMCSioNdem@runcible.example.com/pulp/api/v2/consumers/integration_test_consumer/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Mar 2017 22:34:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: 'null'
+    http_version: 
+  recorded_at: Tue, 28 Mar 2017 22:34:28 GMT
+recorded_with: VCR 3.0.3

--- a/test/resources/consumer_test.rb
+++ b/test/resources/consumer_test.rb
@@ -139,6 +139,13 @@ module Resources
       assert 'finished', task.first['state']
     end
 
+    def test_generate_applicability_one_id
+      response = @resource.regenerate_applicability_by_id(@consumer_id)
+      assert_equal 202, response.code
+      task = RepositorySupport.new.wait_on_response(response)
+      assert 'finished', task.first['state']
+    end
+
     def test_applicability
       criteria = {
         'criteria' => { 'filters' => { 'id' => { '$in' => [@consumer_id] } } },


### PR DESCRIPTION
The previous applicability call would 'lock' on a single worker. This call does
not pin to a single worker, so applicability regeneration can spread across all
workers.

Note that this does not change any functionality, it just exposes a new call
for use by Katello.