### PR TITLE
Support rest_client 2.0

### DIFF
--- a/lib/runcible.rb
+++ b/lib/runcible.rb
@@ -5,6 +5,7 @@ resources = Dir[File.dirname(__FILE__) + '/runcible/version.rb']
 resources += Dir[File.dirname(__FILE__) + '/runcible/base.rb']
 resources += Dir[File.dirname(__FILE__) + '/runcible/instance.rb']
 resources += Dir[File.dirname(__FILE__) + '/runcible/resources/*.rb']
+resources += Dir[File.dirname(__FILE__) + '/runcible/response.rb']
 
 resources += Dir[File.dirname(__FILE__) + '/runcible/extensions/unit.rb']
 resources += Dir[File.dirname(__FILE__) + '/runcible/extensions/*.rb']

--- a/lib/runcible/base.rb
+++ b/lib/runcible/base.rb
@@ -75,8 +75,8 @@ module Runcible
     end
 
     def get_response(client, path, *args)
-      client[path].send(*args) do |response, request, result, &_block|
-        resp = response.return!(request, result)
+      client[path].send(*args) do |response, _request, _result, &_block|
+        resp = response.return!
         log_debug
         return resp
       end
@@ -132,20 +132,12 @@ module Runcible
             i.respond_to?(:with_indifferent_access) ? i.with_indifferent_access : i
           end
         end
-        response = rest_client_response(body, response.net_http_res, response.args)
+        response = Runcible::Response.new(body, response)
       rescue JSON::ParserError
         log_exception
       end
 
       return response
-    end
-
-    def rest_client_response(body, net_http_res, args)
-      if Gem.loaded_specs['rest-client'].version < Gem::Version.create('1.8.0')
-        RestClient::Response.create(body, net_http_res, args)
-      else
-        RestClient::Response.create(body, net_http_res, args, nil)
-      end
     end
 
     def required_params(local_names, binding, keys_to_remove = [])

--- a/lib/runcible/response.rb
+++ b/lib/runcible/response.rb
@@ -1,0 +1,36 @@
+module Runcible
+  class Response
+    attr_accessor :rest_client_response, :parsed_body
+
+    def initialize(parsed_body, rest_client_response)
+      @rest_client_response = rest_client_response
+      @parsed_body = parsed_body
+    end
+
+    def respond_to?(name)
+      @parsed_body.respond_to?(name) || @rest_client_response.respond_to?(name)
+    end
+
+    def ==(other)
+      self.parsed_body == other
+    end
+
+    def is_a?(clazz)
+      self.parsed_body.is_a?(clazz)
+    end
+
+    def body
+      @parsed_body
+    end
+
+    def method_missing(name, *args, &block)
+      if @parsed_body.respond_to?(name)
+        @parsed_body.send(name, *args, &block)
+      elsif @rest_client_response.respond_to?(name)
+        @rest_client_response.send(name, *args, &block)
+      else
+        super
+      end
+    end
+  end
+end

--- a/lib/runcible/version.rb
+++ b/lib/runcible/version.rb
@@ -1,3 +1,3 @@
 module Runcible
-  VERSION = '1.11.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/runcible.gemspec
+++ b/runcible.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Runcible::VERSION
 
   gem.add_dependency('json')
-  gem.add_dependency('rest-client', ['>= 1.6.1', '< 2.0.0'])
+  gem.add_dependency('rest-client', ['>= 1.6.1', '< 3.0.0'])
   gem.add_dependency('oauth')
   gem.add_dependency('activesupport', '>= 3.0.10')
   gem.add_dependency('i18n', '>= 0.5.0')

--- a/test/extensions/repository_test.rb
+++ b/test/extensions/repository_test.rb
@@ -133,9 +133,7 @@ module Extensions
         'yum_importer',
         '2012-10-25T20:44:00Z/P7D'
       )
-      response = @extension.remove_schedules(RepositorySupport.repo_id, 'yum_importer')
-
-      assert_equal 200, response.code
+      @extension.remove_schedules(RepositorySupport.repo_id, 'yum_importer')
     end
 
     def test_retrieve_with_details


### PR DESCRIPTION
Runcible was built around being able to take a
rest client response body, pull out relevant details
and craft a new rest client response object with the boy
being the parsed json rather than the raw json.  Rest Client
2.0 makes this impossible by making the Response object extend
string.

To resolve this while attempting to not break compatibility, we
have introduced a Runcible::Response object that attempts to pass
method calls to the parsed JSON body, and if that does not make
sense, to the Rest Client Response object.

Even still, I still bumped the version to 2.0 in case there is any
change I am not seeing.