### PR TITLE
Add deb repository type

### DIFF
--- a/lib/runcible/extensions/deb.rb
+++ b/lib/runcible/extensions/deb.rb
@@ -1,0 +1,24 @@
+module Runcible
+  module Extensions
+    class Deb < Runcible::Extensions::Unit
+      def self.content_type
+        'deb'
+      end
+
+      # This function is not implemented for DEBs since they do not have content IDs
+      def find
+        fail NotImplementedError
+      end
+
+      # This function is not implemented for DEBs since they do not have content IDs
+      def find_all
+        fail NotImplementedError
+      end
+
+      # This function is not implemented for DEBs since they do not have content IDs
+      def unassociate_ids_from_repo(repo_id, ids)
+        fail NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/runcible/extensions/deb_component.rb
+++ b/lib/runcible/extensions/deb_component.rb
@@ -1,0 +1,24 @@
+module Runcible
+  module Extensions
+    class DebComponent < Runcible::Extensions::Unit
+      def self.content_type
+        'deb_component'
+      end
+
+      # This function is not implemented for Components since they do not have content IDs
+      def find
+        fail NotImplementedError
+      end
+
+      # This function is not implemented for Components since they do not have content IDs
+      def find_all
+        fail NotImplementedError
+      end
+
+      # This function is not implemented for Components since they do not have content IDs
+      def unassociate_ids_from_repo(repo_id, ids)
+        fail NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/runcible/extensions/deb_release.rb
+++ b/lib/runcible/extensions/deb_release.rb
@@ -1,0 +1,24 @@
+module Runcible
+  module Extensions
+    class DebRelease < Runcible::Extensions::Unit
+      def self.content_type
+        'deb_release'
+      end
+
+      # This function is not implemented for Releases since they do not have content IDs
+      def find
+        fail NotImplementedError
+      end
+
+      # This function is not implemented for Releases since they do not have content IDs
+      def find_all
+        fail NotImplementedError
+      end
+
+      # This function is not implemented for Releases since they do not have content IDs
+      def unassociate_ids_from_repo(repo_id, ids)
+        fail NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/runcible/models/deb_distributor.rb
+++ b/lib/runcible/models/deb_distributor.rb
@@ -1,0 +1,33 @@
+require 'active_support/json'
+require 'securerandom'
+
+module Runcible
+  module Models
+    class DebDistributor < Distributor
+      #required attributes
+      attr_accessor 'relative_url', 'http', 'https'
+      #optional attributes
+      attr_accessor 'auth_cert', 'auth_ca',
+                    'https_ca', 'gpgkey', 'generate_metadata',
+                    'checksum_type', 'skip', 'https_publish_dir', 'http_publish_dir'
+
+      def initialize(relative_url, http, https, params = {})
+        @relative_url = relative_url
+        @http = http
+        @https = https
+        super(params)
+      end
+
+      def self.type_id
+        'deb_distributor'
+      end
+
+      def config
+        to_ret = as_json
+        to_ret.delete('auto_publish')
+        to_ret.delete('id')
+        to_ret
+      end
+    end
+  end
+end

--- a/lib/runcible/models/deb_distributor.rb
+++ b/lib/runcible/models/deb_distributor.rb
@@ -9,7 +9,8 @@ module Runcible
       #optional attributes
       attr_accessor 'auth_cert', 'auth_ca',
                     'https_ca', 'gpgkey', 'generate_metadata',
-                    'checksum_type', 'skip', 'https_publish_dir', 'http_publish_dir'
+                    'checksum_type', 'skip', 'https_publish_dir', 'http_publish_dir',
+                    'publish_default_release'
 
       def initialize(relative_url, http, https, params = {})
         @relative_url = relative_url

--- a/lib/runcible/models/deb_importer.rb
+++ b/lib/runcible/models/deb_importer.rb
@@ -1,0 +1,26 @@
+module Runcible
+  module Models
+    class DebImporter < Importer
+      ID = 'deb_importer'.freeze
+      REPO_TYPE = 'deb-repo'.freeze
+      DOWNLOAD_IMMEDIATE = 'immediate'.freeze
+      DOWNLOAD_ON_DEMAND = 'on_demand'.freeze
+      DOWNLOAD_BACKGROUND = 'background'.freeze
+      DOWNLOAD_POLICIES = [DOWNLOAD_IMMEDIATE, DOWNLOAD_ON_DEMAND, DOWNLOAD_BACKGROUND].freeze
+
+      attr_accessor 'download_policy', 'releases', 'components', 'architectures'
+
+      def id
+        DebImporter::ID
+      end
+
+      def repo_type
+        DebImporter::REPO_TYPE
+      end
+
+      def config
+        as_json
+      end
+    end
+  end
+end

--- a/test/extensions/deb_repository_test.rb
+++ b/test/extensions/deb_repository_test.rb
@@ -1,0 +1,89 @@
+require 'rubygems'
+require 'minitest/autorun'
+
+require './test/support/repository_support'
+require './lib/runcible'
+
+module Extensions
+  module TestDebRepositoryBase
+    def setup
+      @support = RepositorySupport.new('deb')
+      @extension = TestRuncible.server.extensions.repository
+    end
+  end
+
+  class TestDebRepositoryCreate < MiniTest::Unit::TestCase
+    include TestDebRepositoryBase
+
+    def teardown
+      @support.destroy_repo
+      super
+    end
+
+    def test_create_with_importer
+      response = @extension.create_with_importer(RepositorySupport.repo_id, :id => 'deb_importer')
+      assert_equal 201, response.code
+
+      response = @extension.retrieve(RepositorySupport.repo_id, :details => true)
+      assert_equal RepositorySupport.repo_id, response['id']
+      assert_equal 'deb_importer', response['importers'].first['importer_type_id']
+    end
+
+    def test_create_with_importer_object
+      response = @extension.create_with_importer(RepositorySupport.repo_id, Runcible::Models::DebImporter.new)
+      assert_equal 201, response.code
+
+      response = @extension.retrieve(RepositorySupport.repo_id, :details => true)
+      assert_equal RepositorySupport.repo_id, response['id']
+      assert_equal 'deb_importer', response['importers'].first['importer_type_id']
+
+      @extension.expects(:create).with(RepositorySupport.repo_id, has_entry(:notes, anything)).returns(true)
+      @extension.create_with_importer(RepositorySupport.repo_id, Runcible::Models::DebImporter.new)
+    end
+
+    def test_create_with_distributors
+      distributors = [{'type_id' => 'deb_distributor', 'id' => '123', 'auto_publish' => true,
+                       'config' => {'relative_url' => '/path', 'http' => true, 'https' => true}}]
+      response = @extension.create_with_distributors(RepositorySupport.repo_id, distributors)
+
+      assert_equal 201, response.code
+      assert_equal RepositorySupport.repo_id, response['id']
+    end
+
+    def test_create_with_distributor_object
+      repo_id = RepositorySupport.repo_id + '_distro'
+      response = @extension.create_with_distributors(repo_id, [Runcible::Models::DebDistributor.new(
+        '/path', true, true, :id => '123')])
+      assert_equal 201, response.code
+
+      response = @extension.retrieve(repo_id, :details => true)
+      assert_equal repo_id, response['id']
+      assert_equal 'deb_distributor', response['distributors'].first['distributor_type_id']
+    ensure
+      @support.destroy_repo(repo_id)
+    end
+
+    def test_create_with_importer_and_distributors
+      distributors = [{'type_id' => 'deb_distributor', 'id' => '234', 'auto_publish' => true,
+                       'config' => {'relative_url' => '/path', 'http' => true, 'https' => true}}]
+      response = @extension.create_with_importer_and_distributors(RepositorySupport.repo_id,
+                                                                 {:id => 'deb_importer'}, distributors)
+      assert_equal 201, response.code
+
+      response = @extension.retrieve(RepositorySupport.repo_id, :details => true)
+      assert_equal RepositorySupport.repo_id, response['id']
+      assert_equal 'deb_distributor', response['distributors'].first['distributor_type_id']
+    end
+
+    def test_create_with_importer_and_distributors_objects
+      distributors = [Runcible::Models::DebDistributor.new('/path', true, true, :id => '123')]
+      importer = Runcible::Models::DebImporter.new
+      response = @extension.create_with_importer_and_distributors(RepositorySupport.repo_id, importer, distributors)
+      assert_equal 201, response.code
+
+      response = @extension.retrieve(RepositorySupport.repo_id, :details => true)
+      assert_equal RepositorySupport.repo_id, response['id']
+      assert_equal 'deb_importer', response['importers'].first['importer_type_id']
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_distributor_object.yml
+++ b/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_distributor_object.yml
@@ -1,0 +1,213 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id_distro","distributors":[{"distributor_type_id":"deb_distributor","distributor_config":{"relative_url":"/path","http":true,"https":true},"auto_publish":false,"distributor_id":"123"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '209'
+      Host:
+      - localhost
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '340'
+      Location:
+      - https://localhost/pulp/api/v2/repositories/integration_test_id_distro/
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id_distro", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "5a05a12e3ca9a00419d21f0c"}, "id": "integration_test_id_distro",
+        "_href": "/pulp/api/v2/repositories/integration_test_id_distro/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:02 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id_distro/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '882'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id_distro", "description":
+        null, "distributors": [{"repo_id": "integration_test_id_distro", "last_updated":
+        "2017-11-10T12:53:02Z", "_href": "/pulp/api/v2/repositories/integration_test_id_distro/distributors/123/",
+        "last_override_config": {}, "last_publish": null, "distributor_type_id": "deb_distributor",
+        "auto_publish": false, "scratchpad": {}, "_ns": "repo_distributors", "_id":
+        {"$oid": "5a05a12e3ca9a00419d21f0d"}, "config": {"http": true, "https": true,
+        "relative_url": "/path"}, "id": "123"}], "last_unit_added": null, "notes":
+        {}, "last_unit_removed": null, "content_unit_counts": {}, "_ns": "repos",
+        "importers": [], "locally_stored_units": 0, "_id": {"$oid": "5a05a12e3ca9a00419d21f0c"},
+        "total_repository_units": 0, "id": "integration_test_id_distro", "_href":
+        "/pulp/api/v2/repositories/integration_test_id_distro/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:02 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id_distro/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/872a0661-1d67-46bb-ad31-b806a969fbb6/",
+        "task_id": "872a0661-1d67-46bb-ad31-b806a969fbb6"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:02 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/tasks/872a0661-1d67-46bb-ad31-b806a969fbb6/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '715'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/872a0661-1d67-46bb-ad31-b806a969fbb6/", "task_id":
+        "872a0661-1d67-46bb-ad31-b806a969fbb6", "tags": ["pulp:repository:integration_test_id_distro",
+        "pulp:action:delete"], "finish_time": "2017-11-10T12:53:02Z", "_ns": "task_status",
+        "start_time": "2017-11-10T12:53:02Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-0@centos7-devel.anubis.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-0@centos7-devel.anubis.example.com",
+        "result": null, "error": null, "_id": {"$oid": "5a05a12ed1897cd5b1e4abe0"},
+        "id": "5a05a12ed1897cd5b1e4abe0"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:03 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '454'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"http_request_method": "DELETE", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:03 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_distributors.yml
+++ b/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_distributors.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","distributors":[{"distributor_type_id":"deb_distributor","distributor_config":{"relative_url":"/path","http":true,"https":true},"auto_publish":true,"distributor_id":"123"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '201'
+      Host:
+      - localhost
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://localhost/pulp/api/v2/repositories/integration_test_id/
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "5a05a12f3ca9a00418176fcf"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:03 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/9c98b1bd-20bc-4950-a818-1e529e0fdd14/",
+        "task_id": "9c98b1bd-20bc-4950-a818-1e529e0fdd14"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:03 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/tasks/9c98b1bd-20bc-4950-a818-1e529e0fdd14/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:04 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '708'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/9c98b1bd-20bc-4950-a818-1e529e0fdd14/", "task_id":
+        "9c98b1bd-20bc-4950-a818-1e529e0fdd14", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-11-10T12:53:03Z", "_ns": "task_status",
+        "start_time": "2017-11-10T12:53:03Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-0@centos7-devel.anubis.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-0@centos7-devel.anubis.example.com",
+        "result": null, "error": null, "_id": {"$oid": "5a05a12fd1897cd5b1e4abe1"},
+        "id": "5a05a12fd1897cd5b1e4abe1"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:04 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_importer.yml
+++ b/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_importer.yml
@@ -1,0 +1,172 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"deb_importer","importer_config":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '83'
+      Host:
+      - localhost
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://localhost/pulp/api/v2/repositories/integration_test_id/
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "5a05a1313ca9a004163109be"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:05 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '777'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "distributors": [], "last_unit_added": null, "notes": {}, "last_unit_removed":
+        null, "content_unit_counts": {}, "_ns": "repos", "importers": [{"repo_id":
+        "integration_test_id", "last_updated": "2017-11-10T12:53:05Z", "_href": "/pulp/api/v2/repositories/integration_test_id/importers/deb_importer/",
+        "_ns": "repo_importers", "importer_type_id": "deb_importer", "last_override_config":
+        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "5a05a1313ca9a004163109bf"},
+        "config": {}, "id": "deb_importer"}], "locally_stored_units": 0, "_id": {"$oid":
+        "5a05a1313ca9a004163109be"}, "total_repository_units": 0, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:05 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/13e5af46-8c98-4d67-829e-eb57e286ad3c/",
+        "task_id": "13e5af46-8c98-4d67-829e-eb57e286ad3c"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:05 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/tasks/13e5af46-8c98-4d67-829e-eb57e286ad3c/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '708'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/13e5af46-8c98-4d67-829e-eb57e286ad3c/", "task_id":
+        "13e5af46-8c98-4d67-829e-eb57e286ad3c", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-11-10T12:53:05Z", "_ns": "task_status",
+        "start_time": "2017-11-10T12:53:05Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-0@centos7-devel.anubis.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-0@centos7-devel.anubis.example.com",
+        "result": null, "error": null, "_id": {"$oid": "5a05a131d1897cd5b1e4abe3"},
+        "id": "5a05a131d1897cd5b1e4abe3"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:05 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_importer_and_distributors.yml
+++ b/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_importer_and_distributors.yml
@@ -1,0 +1,199 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"deb_importer","importer_config":{},"distributors":[{"distributor_type_id":"deb_distributor","distributor_config":{"relative_url":"/","http":true,"https":true},"auto_publish":true,"distributor_id":"234"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '252'
+      Host:
+      - localhost
+  response:
+    status:
+      code: 500
+      message: INTERNAL SERVER ERROR
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 13:07:22 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2560'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"http_request_method": "POST", "exception": ["IndexError: list index
+        out of range\n"], "error_message": "list index out of range", "_href": "/pulp/api/v2/repositories/",
+        "http_status": 500, "traceback": ["  File \"/usr/lib/python2.7/site-packages/django/core/handlers/base.py\",
+        line 112, in get_response\n    response = wrapped_callback(request, *callback_args,
+        **callback_kwargs)\n", "  File \"/usr/lib/python2.7/site-packages/django/views/generic/base.py\",
+        line 69, in view\n    return self.dispatch(request, *args, **kwargs)\n", "  File
+        \"/usr/lib/python2.7/site-packages/django/views/generic/base.py\", line 87,
+        in dispatch\n    return handler(request, *args, **kwargs)\n", "  File \"/usr/lib/python2.7/site-packages/pulp/server/webservices/views/decorators.py\",
+        line 241, in _auth_decorator\n    return _verify_auth(self, operation, super_user_only,
+        method, *args, **kwargs)\n", "  File \"/usr/lib/python2.7/site-packages/pulp/server/webservices/views/decorators.py\",
+        line 195, in _verify_auth\n    value = method(self, *args, **kwargs)\n", "  File
+        \"/usr/lib/python2.7/site-packages/pulp/server/webservices/views/util.py\",
+        line 130, in wrapper\n    return func(*args, **kwargs)\n", "  File \"/usr/lib/python2.7/site-packages/pulp/server/webservices/views/repositories.py\",
+        line 128, in post\n    distributor_list=repo_data.get(''distributors'')\n",
+        "  File \"/usr/lib/python2.7/site-packages/pulp/server/controllers/repository.py\",
+        line 433, in create_repo\n    dist_controller.add_distributor(repo_id, type_id,
+        plugin_config, auto_publish, dist_id)\n", "  File \"/usr/lib/python2.7/site-packages/pulp/server/controllers/distributor.py\",
+        line 67, in add_distributor\n    result = distributor_instance.validate_config(transfer_repo,
+        call_config, config_conduit)\n", "  File \"/usr/lib/python2.7/site-packages/pulp_deb/plugins/distributors/distributor.py\",
+        line 168, in validate_config\n    return configuration.validate_config(repo,
+        config, config_conduit)\n", "  File \"/usr/lib/python2.7/site-packages/pulp_deb/plugins/distributors/configuration.py\",
+        line 90, in validate_config\n    error_messages)\n", "  File \"/usr/lib/python2.7/site-packages/pulp_deb/plugins/distributors/configuration.py\",
+        line 257, in _check_for_relative_path_conflicts\n    conflicting_distributors
+        = config_conduit.get_repo_distributors_by_relative_url(relative_path, repo.id)  #
+        noqa\n", "  File \"/usr/lib/python2.7/site-packages/pulp/plugins/conduits/repo_config.py\",
+        line 46, in get_repo_distributors_by_relative_url\n    repo_id_url = current_url_pieces[0]\n"]}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 13:07:22 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 13:07:22 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '454'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"http_request_method": "DELETE", "exception": null, "error_message":
+        "Missing resource(s): repository=integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/",
+        "http_status": 404, "error": {"code": "PLP0009", "data": {"resources": {"repository":
+        "integration_test_id"}}, "description": "Missing resource(s): repository=integration_test_id",
+        "sub_errors": []}, "traceback": null, "resources": {"repository": "integration_test_id"}}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 13:07:22 GMT
+- request:
+    method: post
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"deb_importer","importer_config":{},"distributors":[{"distributor_type_id":"deb_distributor","distributor_config":{"relative_url":"/path","http":true,"https":true},"auto_publish":true,"distributor_id":"234"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '256'
+      Host:
+      - localhost
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 13:15:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '319'
+      Location:
+      - https://localhost/pulp/api/v2/repositories/integration_test_id/
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "_id": {"$oid": "5a05a6603ca9a004163109c0"}, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 13:15:12 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 13:15:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1211'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "distributors": [{"repo_id": "integration_test_id", "last_updated":
+        "2017-11-10T13:15:12Z", "_href": "/pulp/api/v2/repositories/integration_test_id/distributors/234/",
+        "last_override_config": {}, "last_publish": null, "distributor_type_id": "deb_distributor",
+        "auto_publish": true, "scratchpad": {}, "_ns": "repo_distributors", "_id":
+        {"$oid": "5a05a6603ca9a004163109c2"}, "config": {"http": true, "https": true,
+        "relative_url": "/path"}, "id": "234"}], "last_unit_added": null, "notes":
+        {}, "last_unit_removed": null, "content_unit_counts": {}, "_ns": "repos",
+        "importers": [{"repo_id": "integration_test_id", "last_updated": "2017-11-10T13:15:12Z",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/importers/deb_importer/",
+        "_ns": "repo_importers", "importer_type_id": "deb_importer", "last_override_config":
+        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "5a05a6603ca9a004163109c1"},
+        "config": {}, "id": "deb_importer"}], "locally_stored_units": 0, "_id": {"$oid":
+        "5a05a6603ca9a004163109c0"}, "total_repository_units": 0, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 13:15:12 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_importer_and_distributors_objects.yml
+++ b/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_importer_and_distributors_objects.yml
@@ -1,0 +1,178 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"deb_importer","importer_config":{},"notes":{"_repo-type":"deb-repo"},"distributors":[{"distributor_type_id":"deb_distributor","distributor_config":{"relative_url":"/path","http":true,"https":true},"auto_publish":false,"distributor_id":"123"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '291'
+      Host:
+      - localhost
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:04 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '343'
+      Location:
+      - https://localhost/pulp/api/v2/repositories/integration_test_id/
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {"_repo-type": "deb-repo"}, "last_unit_removed":
+        null, "content_unit_counts": {}, "_ns": "repos", "_id": {"$oid": "5a05a1303ca9a004163109bb"},
+        "id": "integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:04 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:04 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1236'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "distributors": [{"repo_id": "integration_test_id", "last_updated":
+        "2017-11-10T12:53:04Z", "_href": "/pulp/api/v2/repositories/integration_test_id/distributors/123/",
+        "last_override_config": {}, "last_publish": null, "distributor_type_id": "deb_distributor",
+        "auto_publish": false, "scratchpad": {}, "_ns": "repo_distributors", "_id":
+        {"$oid": "5a05a1303ca9a004163109bd"}, "config": {"http": true, "https": true,
+        "relative_url": "/path"}, "id": "123"}], "last_unit_added": null, "notes":
+        {"_repo-type": "deb-repo"}, "last_unit_removed": null, "content_unit_counts":
+        {}, "_ns": "repos", "importers": [{"repo_id": "integration_test_id", "last_updated":
+        "2017-11-10T12:53:04Z", "_href": "/pulp/api/v2/repositories/integration_test_id/importers/deb_importer/",
+        "_ns": "repo_importers", "importer_type_id": "deb_importer", "last_override_config":
+        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "5a05a1303ca9a004163109bc"},
+        "config": {}, "id": "deb_importer"}], "locally_stored_units": 0, "_id": {"$oid":
+        "5a05a1303ca9a004163109bb"}, "total_repository_units": 0, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:04 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:04 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/c1166bb0-a5b6-40df-a938-5971b86fc2db/",
+        "task_id": "c1166bb0-a5b6-40df-a938-5971b86fc2db"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:04 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/tasks/c1166bb0-a5b6-40df-a938-5971b86fc2db/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '708'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/c1166bb0-a5b6-40df-a938-5971b86fc2db/", "task_id":
+        "c1166bb0-a5b6-40df-a938-5971b86fc2db", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-11-10T12:53:04Z", "_ns": "task_status",
+        "start_time": "2017-11-10T12:53:04Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-0@centos7-devel.anubis.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-0@centos7-devel.anubis.example.com",
+        "result": null, "error": null, "_id": {"$oid": "5a05a130d1897cd5b1e4abe2"},
+        "id": "5a05a130d1897cd5b1e4abe2"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:05 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_importer_object.yml
+++ b/test/fixtures/vcr_cassettes/extensions/deb_repository_create/create_with_importer_object.yml
@@ -1,0 +1,173 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      string: '{"id":"integration_test_id","importer_type_id":"deb_importer","importer_config":{},"notes":{"_repo-type":"deb-repo"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '117'
+      Host:
+      - localhost
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '343'
+      Location:
+      - https://localhost/pulp/api/v2/repositories/integration_test_id/
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "last_unit_added": null, "notes": {"_repo-type": "deb-repo"}, "last_unit_removed":
+        null, "content_unit_counts": {}, "_ns": "repos", "_id": {"$oid": "5a05a1323ca9a00418176fd3"},
+        "id": "integration_test_id", "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:06 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/?details=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"scratchpad": {}, "display_name": "integration_test_id", "description":
+        null, "distributors": [], "last_unit_added": null, "notes": {"_repo-type":
+        "deb-repo"}, "last_unit_removed": null, "content_unit_counts": {}, "_ns":
+        "repos", "importers": [{"repo_id": "integration_test_id", "last_updated":
+        "2017-11-10T12:53:06Z", "_href": "/pulp/api/v2/repositories/integration_test_id/importers/deb_importer/",
+        "_ns": "repo_importers", "importer_type_id": "deb_importer", "last_override_config":
+        {}, "last_sync": null, "scratchpad": null, "_id": {"$oid": "5a05a1323ca9a00418176fd4"},
+        "config": {}, "id": "deb_importer"}], "locally_stored_units": 0, "_id": {"$oid":
+        "5a05a1323ca9a00418176fd3"}, "total_repository_units": 0, "id": "integration_test_id",
+        "_href": "/pulp/api/v2/repositories/integration_test_id/"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:06 GMT
+- request:
+    method: delete
+    uri: https://admin:admin@localhost/pulp/api/v2/repositories/integration_test_id/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"spawned_tasks": [{"_href": "/pulp/api/v2/tasks/d9d9322d-7491-4c3f-a077-882edb14ba15/",
+        "task_id": "d9d9322d-7491-4c3f-a077-882edb14ba15"}], "result": null, "error":
+        null}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:06 GMT
+- request:
+    method: get
+    uri: https://admin:admin@localhost/pulp/api/v2/tasks/d9d9322d-7491-4c3f-a077-882edb14ba15/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+      Host:
+      - localhost
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 10 Nov 2017 12:53:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '708'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"exception": null, "task_type": "pulp.server.tasks.repository.delete",
+        "_href": "/pulp/api/v2/tasks/d9d9322d-7491-4c3f-a077-882edb14ba15/", "task_id":
+        "d9d9322d-7491-4c3f-a077-882edb14ba15", "tags": ["pulp:repository:integration_test_id",
+        "pulp:action:delete"], "finish_time": "2017-11-10T12:53:06Z", "_ns": "task_status",
+        "start_time": "2017-11-10T12:53:06Z", "traceback": null, "spawned_tasks":
+        [], "progress_report": {}, "queue": "reserved_resource_worker-0@centos7-devel.anubis.example.com.dq",
+        "state": "finished", "worker_name": "reserved_resource_worker-0@centos7-devel.anubis.example.com",
+        "result": null, "error": null, "_id": {"$oid": "5a05a132d1897cd5b1e4abe4"},
+        "id": "5a05a132d1897cd5b1e4abe4"}'
+    http_version: 
+  recorded_at: Fri, 10 Nov 2017 12:53:06 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This PR is part of the work to integrate deb-repositories into Katello.
It is only sensible in combination with the corresponding branches in pulp_deb and katello:
https://github.com/ATIX-AG/pulp_deb/tree/feature/sync_release_structure
https://github.com/ATIX-AG/katello/tree/feature/add_deb_repository_type