### PR TITLE
Fixes #21161 - Docker manifest list model bindings

### DIFF
--- a/lib/runcible/extensions/docker_manifest_list.rb
+++ b/lib/runcible/extensions/docker_manifest_list.rb
@@ -1,0 +1,9 @@
+module Runcible
+  module Extensions
+    class DockerManifestList < Runcible::Extensions::Unit
+      def self.content_type
+        'docker_manifest_list'
+      end
+    end
+  end
+end

--- a/lib/runcible/extensions/repository.rb
+++ b/lib/runcible/extensions/repository.rb
@@ -278,6 +278,26 @@ module Runcible
         unit_search(id, criteria).map { |i| i['metadata'].with_indifferent_access }
       end
 
+      # Retrieves the docker manifest list IDs for a single repository
+      #
+      # @param  [String]                id the ID of the repository
+      # @return [RestClient::Response]  the set of repository docker manifest IDs
+      def docker_manifest_list_ids(id)
+        criteria = {:type_ids => [Runcible::Extensions::DockerManifestList.content_type],
+                    :fields => {:unit => [], :association => ['unit_id']}}
+
+        unit_search(id, criteria).map { |i| i['unit_id'] }
+      end
+
+      # Retrieves the docker manifest lists for a single repository
+      #
+      # @param  [String]                id the ID of the repository
+      # @return [RestClient::Response]  the set of repository docker manifests
+      def docker_manifest_lists(id)
+        criteria = {:type_ids => [Runcible::Extensions::DockerManifestList.content_type]}
+        unit_search(id, criteria).map { |i| i['metadata'].with_indifferent_access }
+      end
+
       # Retrieves the docker tag IDs for a single repository
       #
       # @param  [String]                id the ID of the repository


### PR DESCRIPTION
Pulp 2.14 added support for docker manifest lists (https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list) as part of https://pulp.plan.io/issues/2384

This PR introduces initial model for this