### PR TITLE
Fixes #22802 - Add 'skip' option to yum

### DIFF
--- a/lib/runcible/models/yum_importer.rb
+++ b/lib/runcible/models/yum_importer.rb
@@ -8,7 +8,7 @@ module Runcible
       DOWNLOAD_BACKGROUND = 'background'.freeze
       DOWNLOAD_POLICIES = [DOWNLOAD_IMMEDIATE, DOWNLOAD_ON_DEMAND, DOWNLOAD_BACKGROUND].freeze
 
-      attr_accessor 'download_policy'
+      attr_accessor 'download_policy', 'type_skip_list'
 
       def id
         YumImporter::ID


### PR DESCRIPTION
Yum importer offers a "skip" option to skip certain unit types while
syncing (like rpms, drpms etc )
This commit is to  make that available to katello and other projects