### PR TITLE
fixes #24370 - don't log binary upload contents

### DIFF
--- a/lib/runcible/base.rb
+++ b/lib/runcible/base.rb
@@ -30,6 +30,7 @@ module Runcible
     end
 
     # rubocop:disable Metrics/AbcSize:
+    # rubocop:disable PerceivedComplexity
     def call(method, path, options = {})
       self.logs = []
       clone_config = self.config.clone
@@ -67,8 +68,9 @@ module Runcible
       args = [method]
       args << generate_payload(options) if [:post, :put].include?(method)
       args << headers
+      starting_arg = options[:no_log_payload] == true ? 2 : 1
+      self.logs << ([method.upcase, URI.join(client.url, path)] + args[starting_arg..-1]).join(': ')
 
-      self.logs << ([method.upcase, URI.join(client.url, path)] + args[1..-1]).join(': ')
       response = get_response(client, path, *args)
       processed = process_response(response)
       self.logs << "Response: #{response.code}: #{response.body}"

--- a/lib/runcible/resources/content.rb
+++ b/lib/runcible/resources/content.rb
@@ -27,7 +27,7 @@ module Runcible
       # @param  [File]    content    content of the file being uploaded to the server
       # @return  [RestClient::Response] none
       def upload_bits(upload_id, offset, content)
-        call(:put, upload_path("#{upload_id}/#{offset}/"), :payload => content)
+        call(:put, upload_path("#{upload_id}/#{offset}/"), :payload => content, :no_log_payload => true)
       end
 
       # Import into a repository


### PR DESCRIPTION
To test, _hammer repository upload-content_ and note that the binary upload is not logged any longer.