### PR TITLE
Refs #25576 - allow passing "subdir" to PuppetInstallDistributor

### DIFF
--- a/lib/runcible/models/puppet_install_distributor.rb
+++ b/lib/runcible/models/puppet_install_distributor.rb
@@ -4,7 +4,7 @@ require 'securerandom'
 module Runcible
   module Models
     class PuppetInstallDistributor < Distributor
-      attr_accessor 'install_path'
+      attr_accessor 'install_path', 'subdir'
 
       def initialize(install_path, params = {})
         @install_path = install_path

--- a/test/models/puppet_install_distributor_test.rb
+++ b/test/models/puppet_install_distributor_test.rb
@@ -5,12 +5,18 @@ require './lib/runcible'
 
 class PuppetInstallDistributorTest < MiniTest::Unit::TestCase
   def setup
-    @dist = Runcible::Models::PuppetInstallDistributor.new('/etc/puppet')
+    @dist = Runcible::Models::PuppetInstallDistributor.new('/etc/puppet', :subdir => 'modules')
   end
 
   def test_config
-    config = {'install_path' => '/etc/puppet', 'auto_publish' => false}
+    config = {'install_path' => '/etc/puppet', 'subdir' => 'modules', 'auto_publish' => false}
     assert_equal config, @dist.config
+  end
+
+  def test_config_nosubdir
+    nosubdir_dist = Runcible::Models::PuppetInstallDistributor.new('/etc/puppet')
+    config = {'install_path' => '/etc/puppet', 'auto_publish' => false}
+    assert_equal config, nosubdir_dist.config
   end
 
   def test_type_id


### PR DESCRIPTION
The relevant pulp-puppet feature was added in 2.13 [1].
It allows pulp-puppet to better clean up the distributor.

[1] https://pulp.plan.io/issues/2108