### PR TITLE
Fixes #26018 - Log HTTP requests at debug level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language:
   - ruby
 
 rvm:
-  - "2.2.0"
-  - "2.3.0"
+  - "2.4.0"
+  - "2.5.0"
 
 before_install:
   - gem install bundler

--- a/lib/runcible/base.rb
+++ b/lib/runcible/base.rb
@@ -74,7 +74,7 @@ module Runcible
       response = get_response(client, path, *args)
       processed = process_response(response)
       self.logs << "Response: #{response.code}: #{response.body}"
-      log_info
+      log_debug
       processed
     rescue RestClient::ResourceNotFound => e
       self.logs << exception_to_log(e)


### PR DESCRIPTION
In Katello we were seeing Pulp requests being logged at info when they should be debug to be consistent with other HTTP logging. I think this was an unintentional change in a recent refactor of the logging.