### PR TITLE
Add support for environment groups

### DIFF
--- a/lib/runcible/extensions/package_environment.rb
+++ b/lib/runcible/extensions/package_environment.rb
@@ -1,0 +1,9 @@
+module Runcible
+  module Extensions
+    class PackageEnvironment < Runcible::Extensions::Unit
+      def self.content_type
+        'package_environment'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is required for copying environment groups when publishing new content view versions.

Related:
https://projects.theforeman.org/issues/27395