### PR TITLE
Filter private keys in logs

### DIFF
--- a/lib/runcible/base.rb
+++ b/lib/runcible/base.rb
@@ -200,16 +200,24 @@ module Runcible
       return headers
     end
 
+    def log_message
+      filter_sensitive_data(self.logs.join("\n"))
+    end
+
+    def filter_sensitive_data(payload)
+      payload.gsub(/-----BEGIN RSA PRIVATE KEY-----[\s\S]*-----END RSA PRIVATE KEY-----/, '[private key filtered]')
+    end
+
     def log_debug
-      self.config[:logging][:logger].debug(self.logs.join("\n")) if self.config[:logging][:debug]
+      logger.debug(log_message) if self.config[:logging][:debug]
     end
 
     def log_exception
-      self.config[:logging][:logger].error(self.logs.join("\n")) if self.config[:logging][:exception]
+      logger.error(log_message) if self.config[:logging][:exception]
     end
 
     def log_info
-      self.config[:logging][:logger].info(self.logs.join("\n")) if self.config[:logging][:info]
+      logger.info(log_message) if self.config[:logging][:info]
     end
 
     def logger


### PR DESCRIPTION
This change filters out RSA private keys before they're logged.  In the log file, the private key is replaced with `[private key filtered]`.

Related: https://github.com/Katello/katello/pull/8667