### PR TITLE
Fixes #33222 - fix respond_to signature

### DIFF
--- a/lib/runcible/response.rb
+++ b/lib/runcible/response.rb
@@ -7,8 +7,8 @@ module Runcible
       @parsed_body = parsed_body
     end
 
-    def respond_to?(name)
-      @parsed_body.respond_to?(name) || @rest_client_response.respond_to?(name)
+    def respond_to?(name, include_all=false)
+      @parsed_body.respond_to?(name, include_all) || @rest_client_response.respond_to?(name, include_all)
     end
 
     def ==(other)


### PR DESCRIPTION
This should help get rid of warning messages like:
warning: Runcible::Response#respond_to?(:to_hash) uses the deprecated method signature, which takes one parameter

